### PR TITLE
feat: upgrade to Apache Arrow v56 for ecosystem compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "arrow"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f15b4c6b148206ff3a2b35002e08929c2462467b62b9c02036d9c34f9ef994"
+checksum = "6e833808ff2d94ed40d9379848a950d995043c7fb3e81a30b383f4c6033821cc"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30feb679425110209ae35c3fbf82404a39a4c0436bb3ec36164d8bffed2a4ce4"
+checksum = "ad08897b81588f60ba983e3ca39bda2b179bdd84dced378e7df81a5313802ef8"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70732f04d285d49054a48b72c54f791bb3424abae92d27aafdf776c98af161c8"
+checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -153,15 +153,15 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "num",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169b1d5d6cb390dd92ce582b06b23815c7953e9dfaaea75556e89d890d19993d"
+checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
 dependencies = [
  "bytes",
  "half",
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
+checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012c9fef3f4a11573b2c74aec53712ff9fdae4a95f4ce452d1bbf088ee00f06b"
+checksum = "bfa9bf02705b5cf762b6f764c65f04ae9082c7cfc4e96e0c33548ee3f67012eb"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -206,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de1ce212d803199684b658fc4ba55fb2d7e87b213de5af415308d2fee3619c2"
+checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -218,14 +218,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea5967e8b2af39aff5d9de2197df16e305f47f404781d3230b2dc672da5d92"
+checksum = "1d3594dcddccc7f20fd069bc8e9828ce37220372680ff638c5e00dea427d88f5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
+ "arrow-select",
  "flatbuffers",
  "lz4_flex",
  "zstd",
@@ -233,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5709d974c4ea5be96d900c01576c7c0b99705f4a3eec343648cb1ca863988a9c"
+checksum = "88cf36502b64a127dc659e3b305f1d993a544eab0d48cce704424e62074dc04b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -255,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6506e3a059e3be23023f587f79c82ef0bcf6d293587e3272d20f2d30b969b5a7"
+checksum = "3c8f82583eb4f8d84d4ee55fd1cb306720cddead7596edce95b50ee418edf66f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -268,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bf7393166beaf79b4bed9bfdf19e97472af32ce5b6b48169d321518a08cae2"
+checksum = "9d07ba24522229d9085031df6b94605e0f4b26e099fb7cdeec37abd941a73753"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -281,15 +282,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
+checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
 
 [[package]]
 name = "arrow-select"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
+checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
@@ -301,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "55.2.0"
+version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0377d532850babb4d927a06294314b316e23311503ed580ec6ce6a0158f49d40"
+checksum = "53f5183c150fbc619eede22b861ea7c0eebed8eaac0333eaa7f6da5205fd504d"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -872,7 +873,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2 0.6.0",
- "strum",
+ "strum 0.27.2",
  "testcontainers",
  "thiserror 2.0.14",
  "tokio",
@@ -918,11 +919,12 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.1.4"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
+checksum = "e0d05af1e006a2407bedef5af410552494ce5be9090444dbbcb57258c1af3d56"
 dependencies = [
- "unicode-segmentation",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "unicode-width",
 ]
 
@@ -1445,6 +1447,12 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -3117,11 +3125,30 @@ dependencies = [
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3587,12 +3614,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"

--- a/clickhouse-arrow-derive/src/ast.rs
+++ b/clickhouse-arrow-derive/src/ast.rs
@@ -8,11 +8,11 @@ use crate::{attr, check};
 /// A source data structure annotated with `#[derive(Row)]`, parsed into an internal representation.
 pub struct Container<'a> {
     /// The struct or enum name (without generics).
-    pub ident:    syn::Ident,
+    pub ident: syn::Ident,
     /// Attributes on the structure, parsed for Serde.
-    pub attrs:    attr::Container,
+    pub attrs: attr::Container,
     /// The contents of the struct or enum.
-    pub data:     Struct<'a>,
+    pub data: Struct<'a>,
     /// Any generics on the struct or enum.
     pub generics: &'a syn::Generics,
     /// Original input.
@@ -26,9 +26,9 @@ pub type Struct<'a> = Vec<Field<'a>>;
 
 /// A field of a struct.
 pub struct Field<'a> {
-    pub member:   syn::Member,
-    pub attrs:    attr::Field,
-    pub ty:       &'a syn::Type,
+    pub member: syn::Member,
+    pub attrs: attr::Field,
+    pub ty: &'a syn::Type,
     pub original: &'a syn::Field,
 }
 
@@ -92,12 +92,12 @@ fn fields_from_ast<'a>(
         .iter()
         .enumerate()
         .map(|(i, field)| Field {
-            member:   match &field.ident {
+            member: match &field.ident {
                 Some(ident) => syn::Member::Named(ident.clone()),
                 None => syn::Member::Unnamed(i.into()),
             },
-            attrs:    attr::Field::from_ast(cx, i, field, container_default),
-            ty:       &field.ty,
+            attrs: attr::Field::from_ast(cx, i, field, container_default),
+            ty: &field.ty,
             original: field,
         })
         .collect()

--- a/clickhouse-arrow-derive/src/attr.rs
+++ b/clickhouse-arrow-derive/src/attr.rs
@@ -17,10 +17,10 @@ use crate::respan::respan;
 use crate::symbol::*;
 
 struct Attr<'c, T> {
-    cx:     &'c Ctxt,
-    name:   Symbol,
+    cx: &'c Ctxt,
+    name: Symbol,
     tokens: TokenStream,
-    value:  Option<T>,
+    value: Option<T>,
 }
 
 impl<'c, T> Attr<'c, T> {
@@ -54,25 +54,35 @@ impl<'c, T> Attr<'c, T> {
         }
     }
 
-    fn get(self) -> Option<T> { self.value }
+    fn get(self) -> Option<T> {
+        self.value
+    }
 }
 
 struct BoolAttr<'c>(Attr<'c, ()>);
 
 impl<'c> BoolAttr<'c> {
-    fn none(cx: &'c Ctxt, name: Symbol) -> Self { BoolAttr(Attr::none(cx, name)) }
+    fn none(cx: &'c Ctxt, name: Symbol) -> Self {
+        BoolAttr(Attr::none(cx, name))
+    }
 
-    fn set_true<A: ToTokens>(&mut self, obj: A) { self.0.set(obj, ()); }
+    fn set_true<A: ToTokens>(&mut self, obj: A) {
+        self.0.set(obj, ());
+    }
 
-    fn get(&self) -> bool { self.0.value.is_some() }
+    fn get(&self) -> bool {
+        self.0.value.is_some()
+    }
 }
 
 pub struct Name {
-    name:    String,
+    name: String,
     renamed: bool,
 }
 
-fn unraw(ident: &Ident) -> String { ident.to_string().trim_start_matches("r#").to_owned() }
+fn unraw(ident: &Ident) -> String {
+    ident.to_string().trim_start_matches("r#").to_owned()
+}
 
 impl Name {
     fn from_attrs(source_name: String, rename: Attr<String>) -> Name {
@@ -80,20 +90,22 @@ impl Name {
         Name { renamed: rename.is_some(), name: rename.unwrap_or_else(|| source_name.clone()) }
     }
 
-    pub fn name(&self) -> String { self.name.clone() }
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
 }
 
 pub struct Container {
     deny_unknown_fields: bool,
-    default:             Default,
-    rename_all_rule:     RenameRule,
-    bound:               Option<Vec<syn::WherePredicate>>,
-    type_from:           Option<syn::Type>,
-    type_try_from:       Option<syn::Type>,
-    type_into:           Option<syn::Type>,
+    default: Default,
+    rename_all_rule: RenameRule,
+    bound: Option<Vec<syn::WherePredicate>>,
+    type_from: Option<syn::Type>,
+    type_try_from: Option<syn::Type>,
+    type_into: Option<syn::Type>,
     // #[clickhouse_arrow(schema = "get_schema")]
-    schema:              Option<syn::ExprPath>,
-    is_packed:           bool,
+    schema: Option<syn::ExprPath>,
+    is_packed: bool,
 }
 
 impl Container {
@@ -272,37 +284,53 @@ impl Container {
         }
     }
 
-    pub fn rename_all_rule(&self) -> &RenameRule { &self.rename_all_rule }
+    pub fn rename_all_rule(&self) -> &RenameRule {
+        &self.rename_all_rule
+    }
 
-    pub fn deny_unknown_fields(&self) -> bool { self.deny_unknown_fields }
+    pub fn deny_unknown_fields(&self) -> bool {
+        self.deny_unknown_fields
+    }
 
-    pub fn default(&self) -> &Default { &self.default }
+    pub fn default(&self) -> &Default {
+        &self.default
+    }
 
     pub fn bound(&self) -> Option<&[syn::WherePredicate]> {
         self.bound.as_ref().map(|vec| &vec[..])
     }
 
-    pub fn type_from(&self) -> Option<&syn::Type> { self.type_from.as_ref() }
+    pub fn type_from(&self) -> Option<&syn::Type> {
+        self.type_from.as_ref()
+    }
 
-    pub fn type_try_from(&self) -> Option<&syn::Type> { self.type_try_from.as_ref() }
+    pub fn type_try_from(&self) -> Option<&syn::Type> {
+        self.type_try_from.as_ref()
+    }
 
-    pub fn type_into(&self) -> Option<&syn::Type> { self.type_into.as_ref() }
+    pub fn type_into(&self) -> Option<&syn::Type> {
+        self.type_into.as_ref()
+    }
 
-    pub fn schema(&self) -> Option<&syn::ExprPath> { self.schema.as_ref() }
+    pub fn schema(&self) -> Option<&syn::ExprPath> {
+        self.schema.as_ref()
+    }
 
-    pub fn is_packed(&self) -> bool { self.is_packed }
+    pub fn is_packed(&self) -> bool {
+        self.is_packed
+    }
 }
 
 pub struct Field {
-    name:               Name,
-    skip_serializing:   bool,
+    name: Name,
+    skip_serializing: bool,
     skip_deserializing: bool,
-    default:            Default,
-    serialize_with:     Option<syn::ExprPath>,
-    deserialize_with:   Option<syn::ExprPath>,
-    bound:              Option<Vec<syn::WherePredicate>>,
-    nested:             bool,
-    flatten:            bool,
+    default: Default,
+    serialize_with: Option<syn::ExprPath>,
+    deserialize_with: Option<syn::ExprPath>,
+    bound: Option<Vec<syn::WherePredicate>>,
+    nested: bool,
+    flatten: bool,
 }
 
 #[allow(clippy::enum_variant_names)]
@@ -435,19 +463,21 @@ impl Field {
         }
 
         Field {
-            name:               Name::from_attrs(ident, rename),
-            skip_serializing:   skip_serializing.get(),
+            name: Name::from_attrs(ident, rename),
+            skip_serializing: skip_serializing.get(),
             skip_deserializing: skip_deserializing.get(),
-            default:            default.get().unwrap_or(Default::None),
-            serialize_with:     serialize_with.get(),
-            deserialize_with:   deserialize_with.get(),
-            bound:              bound.get(),
-            nested:             nested.get(),
-            flatten:            flatten.get(),
+            default: default.get().unwrap_or(Default::None),
+            serialize_with: serialize_with.get(),
+            deserialize_with: deserialize_with.get(),
+            bound: bound.get(),
+            nested: nested.get(),
+            flatten: flatten.get(),
         }
     }
 
-    pub fn name(&self) -> &Name { &self.name }
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
 
     pub fn rename_by_rules(&mut self, rules: &RenameRule) {
         if !self.name.renamed {
@@ -455,19 +485,33 @@ impl Field {
         }
     }
 
-    pub fn flatten(&self) -> bool { self.flatten }
+    pub fn flatten(&self) -> bool {
+        self.flatten
+    }
 
-    pub fn nested(&self) -> bool { self.nested }
+    pub fn nested(&self) -> bool {
+        self.nested
+    }
 
-    pub fn skip_serializing(&self) -> bool { self.skip_serializing }
+    pub fn skip_serializing(&self) -> bool {
+        self.skip_serializing
+    }
 
-    pub fn skip_deserializing(&self) -> bool { self.skip_deserializing }
+    pub fn skip_deserializing(&self) -> bool {
+        self.skip_deserializing
+    }
 
-    pub fn default(&self) -> &Default { &self.default }
+    pub fn default(&self) -> &Default {
+        &self.default
+    }
 
-    pub fn serialize_with(&self) -> Option<&syn::ExprPath> { self.serialize_with.as_ref() }
+    pub fn serialize_with(&self) -> Option<&syn::ExprPath> {
+        self.serialize_with.as_ref()
+    }
 
-    pub fn deserialize_with(&self) -> Option<&syn::ExprPath> { self.deserialize_with.as_ref() }
+    pub fn deserialize_with(&self) -> Option<&syn::ExprPath> {
+        self.deserialize_with.as_ref()
+    }
 
     pub fn bound(&self) -> Option<&[syn::WherePredicate]> {
         self.bound.as_ref().map(|vec| &vec[..])

--- a/clickhouse-arrow-derive/src/bound.rs
+++ b/clickhouse-arrow-derive/src/bound.rs
@@ -56,8 +56,8 @@ pub fn with_bound(
     bound: &[&syn::Path],
 ) -> syn::Generics {
     struct FindTyParams<'ast> {
-        all_type_params:       HashSet<syn::Ident>,
-        relevant_type_params:  HashSet<syn::Ident>,
+        all_type_params: HashSet<syn::Ident>,
+        relevant_type_params: HashSet<syn::Ident>,
         associated_type_usage: Vec<&'ast syn::TypePath>,
     }
 
@@ -198,17 +198,17 @@ pub fn with_bound(
         .chain(associated_type_usage.into_iter().cloned())
         .map(|bounded_ty| {
             syn::WherePredicate::Type(syn::PredicateType {
-                lifetimes:   None,
-                bounded_ty:  syn::Type::Path(bounded_ty),
+                lifetimes: None,
+                bounded_ty: syn::Type::Path(bounded_ty),
                 colon_token: <syn::token::Colon>::default(),
-                bounds:      bound
+                bounds: bound
                     .iter()
                     .map(|bound| {
                         syn::TypeParamBound::Trait(syn::TraitBound {
                             paren_token: None,
-                            modifier:    syn::TraitBoundModifier::None,
-                            lifetimes:   None,
-                            path:        (*bound).clone(),
+                            modifier: syn::TraitBoundModifier::None,
+                            lifetimes: None,
+                            path: (*bound).clone(),
                         })
                     })
                     .collect(),

--- a/clickhouse-arrow-derive/src/check.rs
+++ b/clickhouse-arrow-derive/src/check.rs
@@ -3,7 +3,9 @@ use crate::ctxt::Ctxt;
 
 /// Cross-cutting checks that require looking at more than a single attrs
 /// object. Simpler checks should happen when parsing and building the attrs.
-pub fn check(cx: &Ctxt, cont: &mut Container) { check_from_and_try_from(cx, cont); }
+pub fn check(cx: &Ctxt, cont: &mut Container) {
+    check_from_and_try_from(cx, cont);
+}
 
 fn check_from_and_try_from(cx: &Ctxt, cont: &mut Container) {
     if cont.attrs.type_from().is_some() && cont.attrs.type_try_from().is_some() {

--- a/clickhouse-arrow-derive/src/ctxt.rs
+++ b/clickhouse-arrow-derive/src/ctxt.rs
@@ -20,7 +20,9 @@ impl Ctxt {
     /// Create a new context object.
     ///
     /// This object contains no errors, but will still trigger a panic if it is not `check`ed.
-    pub fn new() -> Self { Ctxt { errors: RefCell::new(Some(Vec::new())) } }
+    pub fn new() -> Self {
+        Ctxt { errors: RefCell::new(Some(Vec::new())) }
+    }
 
     /// Add an error to the context object with a tokenenizable object.
     ///

--- a/clickhouse-arrow-derive/src/receiver.rs
+++ b/clickhouse-arrow-derive/src/receiver.rs
@@ -42,7 +42,7 @@ impl ReplaceReceiver<'_> {
         let span = path.segments[0].ident.span();
         *qself = Some(QSelf {
             lt_token: syn::token::Lt { spans: [span] },
-            ty:       Box::new(Type::Path(self.self_ty(span))),
+            ty: Box::new(Type::Path(self.self_ty(span))),
             position: 0,
             as_token: None,
             gt_token: syn::token::Gt { spans: [span] },

--- a/clickhouse-arrow-derive/src/row.rs
+++ b/clickhouse-arrow-derive/src/row.rs
@@ -45,10 +45,12 @@ fn build_generics(cont: &Container) -> syn::Generics {
 
     match cont.attrs.bound() {
         Some(predicates) => bound::with_where_predicates(&generics, predicates),
-        None => bound::with_bound(cont, &generics, needs_serialize_bound, &[
-            &parse_quote!(::clickhouse_arrow::FromSql),
-            &parse_quote!(::clickhouse_arrow::ToSql),
-        ]),
+        None => bound::with_bound(
+            cont,
+            &generics,
+            needs_serialize_bound,
+            &[&parse_quote!(::clickhouse_arrow::FromSql), &parse_quote!(::clickhouse_arrow::ToSql)],
+        ),
     }
 }
 
@@ -381,7 +383,9 @@ fn deserialize_struct(params: &Parameters, fields: &[Field], cattrs: &attr::Cont
     }
 }
 
-fn field_i(i: usize) -> Ident { Ident::new(&format!("__field{}", i), Span::call_site()) }
+fn field_i(i: usize) -> Ident {
+    Ident::new(&format!("__field{}", i), Span::call_site())
+}
 
 fn deserialize_map(
     struct_path: &TokenStream,

--- a/clickhouse-arrow-derive/src/symbol.rs
+++ b/clickhouse-arrow-derive/src/symbol.rs
@@ -26,21 +26,31 @@ pub const WITH: Symbol = Symbol("with");
 pub const CLICKHOUSE_NATIVE: Symbol = Symbol("clickhouse_arrow");
 
 impl PartialEq<Symbol> for Ident {
-    fn eq(&self, word: &Symbol) -> bool { self == word.0 }
+    fn eq(&self, word: &Symbol) -> bool {
+        self == word.0
+    }
 }
 
 impl PartialEq<Symbol> for &'_ Ident {
-    fn eq(&self, word: &Symbol) -> bool { *self == word.0 }
+    fn eq(&self, word: &Symbol) -> bool {
+        *self == word.0
+    }
 }
 
 impl PartialEq<Symbol> for Path {
-    fn eq(&self, word: &Symbol) -> bool { self.is_ident(word.0) }
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
 }
 
 impl PartialEq<Symbol> for &'_ Path {
-    fn eq(&self, word: &Symbol) -> bool { self.is_ident(word.0) }
+    fn eq(&self, word: &Symbol) -> bool {
+        self.is_ident(word.0)
+    }
 }
 
 impl Display for Symbol {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result { formatter.write_str(self.0) }
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(self.0)
+    }
 }

--- a/clickhouse-arrow/Cargo.toml
+++ b/clickhouse-arrow/Cargo.toml
@@ -52,7 +52,7 @@ test-utils = [
 # DEPENDENCIES
 
 [dependencies]
-arrow = { version = "55", features = [
+arrow = { version = "56", features = [
     "prettyprint",
     "ipc_compression",
     "chrono-tz",

--- a/clickhouse-arrow/benches/common/mod.rs
+++ b/clickhouse-arrow/benches/common/mod.rs
@@ -18,18 +18,18 @@ pub(crate) const DEFAULT_INSERT_SAMPLE_SIZE: usize = 50;
 
 #[derive(ClickHouseRow, Clone, Serialize, Deserialize)]
 pub(crate) struct ClickHouseRsRow {
-    id:    String,
-    name:  String,
+    id: String,
+    name: String,
     value: f64,
-    ts:    i64, // DateTime64(3) maps to i64 milliseconds
+    ts: i64, // DateTime64(3) maps to i64 milliseconds
 }
 
 #[derive(Row, Clone, Serialize, Deserialize)]
 pub(crate) struct ClickHouseNativeRow {
-    id:    String,
-    name:  String,
+    id: String,
+    name: String,
     value: f64,
-    ts:    DateTime64<3>,
+    ts: DateTime64<3>,
 }
 
 pub(crate) fn init() {
@@ -74,10 +74,10 @@ pub(crate) fn setup_clickhouse_rs(ch: &'static ClickHouseContainer) -> ClickHous
 pub(crate) fn create_test_rows(rows: usize) -> Vec<ClickHouseRsRow> {
     (0..rows)
         .map(|i| ClickHouseRsRow {
-            id:    Uuid::new_v4().to_string(),
-            name:  format!("name{i}"),
+            id: Uuid::new_v4().to_string(),
+            name: format!("name{i}"),
             value: i as f64,
-            ts:    i as i64 * 1000,
+            ts: i as i64 * 1000,
         })
         .collect()
 }
@@ -89,10 +89,10 @@ pub(crate) fn create_test_rows(rows: usize) -> Vec<ClickHouseRsRow> {
 pub(crate) fn create_test_native_rows(rows: usize) -> Vec<ClickHouseNativeRow> {
     (0..rows)
         .map(|i| ClickHouseNativeRow {
-            id:    Uuid::new_v4().to_string(),
-            name:  format!("name{i}"),
+            id: Uuid::new_v4().to_string(),
+            name: format!("name{i}"),
             value: i as f64,
-            ts:    DateTime64::<3>::try_from(
+            ts: DateTime64::<3>::try_from(
                 chrono::DateTime::<chrono::Utc>::from_timestamp(i as i64 * 1000, 0).unwrap(),
             )
             .unwrap(),

--- a/clickhouse-arrow/src/arrow/block.rs
+++ b/clickhouse-arrow/src/arrow/block.rs
@@ -363,10 +363,13 @@ mod tests {
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, true),
         ]));
-        RecordBatch::try_new(schema, vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
-            Arc::new(StringArray::from(vec![Some("alice"), None, Some("bob")])),
-        ])
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![Some("alice"), None, Some("bob")])),
+            ],
+        )
         .unwrap()
     }
 
@@ -509,11 +512,11 @@ mod tests {
     #[tokio::test]
     async fn test_round_trip_single_column_int32() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                1, 2, 3,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default();
         let mut buffer = Cursor::new(Vec::new());
@@ -598,9 +601,10 @@ mod tests {
             deserialized_values.values().as_ref(),
             Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50])).as_ref()
         );
-        assert_eq!(deserialized_values.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            deserialized_values.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
     }
 
     /// Tests round-trip serialization and deserialization of a `RecordBatch` with a Map column.
@@ -660,18 +664,20 @@ mod tests {
             struct_array.column(1).as_any().downcast_ref::<Int32Array>().unwrap(),
             &Int32Array::from(vec![1, 2, 3, 4, 5])
         );
-        assert_eq!(deserialized_map.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            deserialized_map.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
     }
 
     /// Tests round-trip serialization and deserialization of a `RecordBatch` with zero rows.
     #[tokio::test]
     async fn test_round_trip_zero_rows() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(
-            Vec::<i32>::new(),
-        ))])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(Vec::<i32>::new()))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -738,11 +744,11 @@ mod tests {
     #[tokio::test]
     async fn test_round_trip_with_header() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                1, 2, 3,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
 
         let header = vec![("id".to_string(), Type::Int32)];
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -777,13 +783,11 @@ mod tests {
     #[tokio::test]
     async fn test_round_trip_strings_as_binary() {
         let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Binary, true)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(BinaryArray::from(vec![
-                Some(b"a" as &[u8]),
-                None,
-                Some(b"c" as &[u8]),
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(BinaryArray::from(vec![Some(b"a" as &[u8]), None, Some(b"c" as &[u8])]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(false);
         let mut buffer = Cursor::new(Vec::new());
@@ -817,11 +821,11 @@ mod tests {
     #[tokio::test]
     async fn test_round_trip_float64() {
         let schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Float64, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Float64Array::from(vec![
-                1.5, -2.0, 3.1,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Float64Array::from(vec![1.5, -2.0, 3.1]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Cursor::new(Vec::new());
@@ -859,10 +863,13 @@ mod tests {
             DataType::Timestamp(TimeUnit::Second, Some("UTC".into())),
             true,
         )]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-            TimestampSecondArray::from(vec![Some(1000), None, Some(3000)])
-                .with_timezone_opt(Some("UTC")),
-        )])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(
+                TimestampSecondArray::from(vec![Some(1000), None, Some(3000)])
+                    .with_timezone_opt(Some("UTC")),
+            )],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -902,11 +909,14 @@ mod tests {
     async fn test_round_trip_decimal128() {
         let schema =
             Arc::new(Schema::new(vec![Field::new("price", DataType::Decimal128(18, 4), false)]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-            Decimal128Array::from(vec![10000, 20000, 30000])
-                .with_precision_and_scale(18, 4)
-                .unwrap(),
-        )])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(
+                Decimal128Array::from(vec![10000, 20000, 30000])
+                    .with_precision_and_scale(18, 4)
+                    .unwrap(),
+            )],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -950,11 +960,11 @@ mod tests {
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-                DictionaryArray::<Int32Type>::from_iter(vec!["cat", "dog", "cat"]),
-            )])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(DictionaryArray::<Int32Type>::from_iter(vec!["cat", "dog", "cat"]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Cursor::new(Vec::new());
@@ -994,9 +1004,12 @@ mod tests {
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(
-            DictionaryArray::<Int8Type>::from_iter(vec!["active", "inactive", "active"]),
-        )])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(DictionaryArray::<Int8Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -1116,9 +1129,12 @@ mod tests {
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(
-            DictionaryArray::<Int8Type>::from_iter(vec!["active", "inactive", "active"]),
-        )])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(DictionaryArray::<Int8Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -1166,9 +1182,12 @@ mod tests {
             DataType::Dictionary(Box::new(DataType::Int16), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(
-            DictionaryArray::<Int16Type>::from_iter(vec!["active", "inactive", "active"]),
-        )])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(DictionaryArray::<Int16Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -1215,11 +1234,13 @@ mod tests {
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-                DictionaryArray::<Int32Type>::from_iter(vec!["active", "inactive", "active"]),
-            )])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Cursor::new(Vec::new());
@@ -1348,12 +1369,14 @@ mod tests {
     #[tokio::test]
     async fn test_round_trip_non_utf8_binary() {
         let schema = Arc::new(Schema::new(vec![Field::new("data", DataType::Binary, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(BinaryArray::from_vec(vec![
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(BinaryArray::from_vec(vec![
                 b"\xFF\xFE" as &[u8], // Non-UTF-8
                 b"\x00\x01" as &[u8],
-            ]))])
-            .unwrap();
+            ]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(false);
         let mut buffer = Cursor::new(Vec::new());
@@ -1388,13 +1411,11 @@ mod tests {
     #[tokio::test]
     async fn test_round_trip_max_min_int32() {
         let schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                i32::MIN,
-                0,
-                i32::MAX,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![i32::MIN, 0, i32::MAX]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Cursor::new(Vec::new());
@@ -1427,11 +1448,11 @@ mod tests {
     #[tokio::test]
     async fn test_header_type_mismatch() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                1, 2, 3,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
         let header = vec![("id".to_string(), Type::String)]; // Mismatch: Int32 vs String
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -1456,14 +1477,17 @@ mod tests {
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
             true,
         )]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-            DictionaryArray::<Int32Type>::try_new(
-                Int32Array::from(vec![Some(0), Some(3), Some(1), None, Some(2)]),
-                Arc::new(StringArray::from(vec!["active", "inactive", "pending", "absent"]))
-                    as ArrayRef,
-            )
-            .unwrap(),
-        )])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(
+                DictionaryArray::<Int32Type>::try_new(
+                    Int32Array::from(vec![Some(0), Some(3), Some(1), None, Some(2)]),
+                    Arc::new(StringArray::from(vec!["active", "inactive", "pending", "absent"]))
+                        as ArrayRef,
+                )
+                .unwrap(),
+            )],
+        )
         .expect("Failed to create RecordBatch");
 
         let mut writer = Cursor::new(Vec::new());
@@ -1560,10 +1584,13 @@ mod tests_sync {
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, true),
         ]));
-        RecordBatch::try_new(schema, vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
-            Arc::new(StringArray::from(vec![Some("alice"), None, Some("bob")])),
-        ])
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(StringArray::from(vec![Some("alice"), None, Some("bob")])),
+            ],
+        )
         .unwrap()
     }
 
@@ -1685,11 +1712,11 @@ mod tests_sync {
     #[test]
     fn test_round_trip_single_column_int32() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                1, 2, 3,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default();
         let mut buffer = Vec::new();
@@ -1758,9 +1785,10 @@ mod tests_sync {
             deserialized_values.values().as_ref(),
             Arc::new(Int32Array::from(vec![10, 20, 30, 40, 50])).as_ref()
         );
-        assert_eq!(deserialized_values.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            deserialized_values.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
     }
 
     /// Tests round-trip serialization and deserialization of a `RecordBatch` with a Map column.
@@ -1811,18 +1839,20 @@ mod tests_sync {
             struct_array.column(1).as_any().downcast_ref::<Int32Array>().unwrap(),
             &Int32Array::from(vec![1, 2, 3, 4, 5])
         );
-        assert_eq!(deserialized_map.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            deserialized_map.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
     }
 
     /// Tests round-trip serialization and deserialization of a `RecordBatch` with zero rows.
     #[test]
     fn test_round_trip_zero_rows() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(
-            Vec::<i32>::new(),
-        ))])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(Vec::<i32>::new()))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -1871,11 +1901,11 @@ mod tests_sync {
     #[test]
     fn test_round_trip_with_header() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                1, 2, 3,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
 
         let header = vec![("id".to_string(), Type::Int32)];
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -1904,13 +1934,11 @@ mod tests_sync {
     #[test]
     fn test_round_trip_strings_as_binary() {
         let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Binary, true)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(BinaryArray::from(vec![
-                Some(b"a" as &[u8]),
-                None,
-                Some(b"c" as &[u8]),
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(BinaryArray::from(vec![Some(b"a" as &[u8]), None, Some(b"c" as &[u8])]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(false);
         let mut buffer = Vec::new();
@@ -1935,11 +1963,11 @@ mod tests_sync {
     #[test]
     fn test_round_trip_float64() {
         let schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Float64, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Float64Array::from(vec![
-                1.5, -2.0, 3.1,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Float64Array::from(vec![1.5, -2.0, 3.1]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Vec::new();
@@ -1968,10 +1996,13 @@ mod tests_sync {
             DataType::Timestamp(TimeUnit::Second, Some("UTC".into())),
             true,
         )]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-            TimestampSecondArray::from(vec![Some(1000), None, Some(3000)])
-                .with_timezone_opt(Some("UTC")),
-        )])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(
+                TimestampSecondArray::from(vec![Some(1000), None, Some(3000)])
+                    .with_timezone_opt(Some("UTC")),
+            )],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -2002,11 +2033,14 @@ mod tests_sync {
     fn test_round_trip_decimal128() {
         let schema =
             Arc::new(Schema::new(vec![Field::new("price", DataType::Decimal128(18, 4), false)]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-            Decimal128Array::from(vec![10000, 20000, 30000])
-                .with_precision_and_scale(18, 4)
-                .unwrap(),
-        )])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(
+                Decimal128Array::from(vec![10000, 20000, 30000])
+                    .with_precision_and_scale(18, 4)
+                    .unwrap(),
+            )],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -2041,11 +2075,11 @@ mod tests_sync {
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-                DictionaryArray::<Int32Type>::from_iter(vec!["cat", "dog", "cat"]),
-            )])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(DictionaryArray::<Int32Type>::from_iter(vec!["cat", "dog", "cat"]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Vec::new();
@@ -2076,9 +2110,12 @@ mod tests_sync {
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(
-            DictionaryArray::<Int8Type>::from_iter(vec!["active", "inactive", "active"]),
-        )])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(DictionaryArray::<Int8Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -2183,9 +2220,12 @@ mod tests_sync {
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(
-            DictionaryArray::<Int8Type>::from_iter(vec!["active", "inactive", "active"]),
-        )])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(DictionaryArray::<Int8Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -2227,9 +2267,12 @@ mod tests_sync {
             DataType::Dictionary(Box::new(DataType::Int16), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(
-            DictionaryArray::<Int16Type>::from_iter(vec!["active", "inactive", "active"]),
-        )])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(DictionaryArray::<Int16Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
         .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -2267,11 +2310,13 @@ mod tests_sync {
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
             false,
         )]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-                DictionaryArray::<Int32Type>::from_iter(vec!["active", "inactive", "active"]),
-            )])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(DictionaryArray::<Int32Type>::from_iter(vec![
+                "active", "inactive", "active",
+            ]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Vec::new();
@@ -2373,12 +2418,14 @@ mod tests_sync {
     #[test]
     fn test_round_trip_non_utf8_binary() {
         let schema = Arc::new(Schema::new(vec![Field::new("data", DataType::Binary, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(BinaryArray::from_vec(vec![
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(BinaryArray::from_vec(vec![
                 b"\xFF\xFE" as &[u8], // Non-UTF-8
                 b"\x00\x01" as &[u8],
-            ]))])
-            .unwrap();
+            ]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(false);
         let mut buffer = Vec::new();
@@ -2404,13 +2451,11 @@ mod tests_sync {
     #[test]
     fn test_round_trip_max_min_int32() {
         let schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                i32::MIN,
-                0,
-                i32::MAX,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![i32::MIN, 0, i32::MAX]))],
+        )
+        .unwrap();
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
         let mut buffer = Vec::new();
@@ -2434,11 +2479,11 @@ mod tests_sync {
     #[test]
     fn test_header_type_mismatch() {
         let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
-        let batch =
-            RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(Int32Array::from(vec![
-                1, 2, 3,
-            ]))])
-            .unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
         let header = vec![("id".to_string(), Type::String)]; // Mismatch: Int32 vs String
 
         let arrow_options = ArrowOptions::default().with_strings_as_strings(true);
@@ -2465,14 +2510,17 @@ mod tests_sync {
             DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
             true,
         )]));
-        let batch = RecordBatch::try_new(Arc::clone(&schema), vec![Arc::new(
-            DictionaryArray::<Int32Type>::try_new(
-                Int32Array::from(vec![Some(0), Some(3), Some(1), None, Some(2)]),
-                Arc::new(StringArray::from(vec!["active", "inactive", "pending", "absent"]))
-                    as ArrayRef,
-            )
-            .unwrap(),
-        )])
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(
+                DictionaryArray::<Int32Type>::try_new(
+                    Int32Array::from(vec![Some(0), Some(3), Some(1), None, Some(2)]),
+                    Arc::new(StringArray::from(vec!["active", "inactive", "pending", "absent"]))
+                        as ArrayRef,
+                )
+                .unwrap(),
+            )],
+        )
         .expect("Failed to create RecordBatch");
 
         let mut writer = Vec::new();

--- a/clickhouse-arrow/src/arrow/builder/dictionary.rs
+++ b/clickhouse-arrow/src/arrow/builder/dictionary.rs
@@ -40,7 +40,7 @@ impl LowCardinalityKeyBuilder {
 }
 
 pub(crate) struct LowCardinalityBuilder {
-    pub(crate) key_builder:   LowCardinalityKeyBuilder,
+    pub(crate) key_builder: LowCardinalityKeyBuilder,
     pub(crate) value_builder: Box<TypedBuilder>,
 }
 

--- a/clickhouse-arrow/src/arrow/deserialize.rs
+++ b/clickhouse-arrow/src/arrow/deserialize.rs
@@ -33,9 +33,9 @@ use crate::{ArrowOptions, Error, Result, Type};
 #[derive(Default)]
 pub(crate) struct ArrowDeserializerState {
     pub(crate) builders: Vec<TypedBuilder>,
-    pub(crate) buffer:   Vec<u8>,
-    fields:              Vec<FieldRef>,
-    arrays:              Vec<ArrayRef>,
+    pub(crate) buffer: Vec<u8>,
+    fields: Vec<FieldRef>,
+    arrays: Vec<ArrayRef>,
 }
 
 impl ArrowDeserializerState {
@@ -790,9 +790,10 @@ mod tests {
         assert_eq!(list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 2, 5]);
-        assert_eq!(list_array.nulls().unwrap().iter().collect::<Vec<bool>>(), vec![
-            true, false, true
-        ]);
+        assert_eq!(
+            list_array.nulls().unwrap().iter().collect::<Vec<bool>>(),
+            vec![true, false, true]
+        );
     }
 
     /// Tests deserialization of `Map(String, Int32)` with non-nullable key-value pairs.
@@ -1063,9 +1064,10 @@ mod tests_sync {
         assert_eq!(list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 2, 5]);
-        assert_eq!(list_array.nulls().unwrap().iter().collect::<Vec<bool>>(), vec![
-            true, false, true
-        ]);
+        assert_eq!(
+            list_array.nulls().unwrap().iter().collect::<Vec<bool>>(),
+            vec![true, false, true]
+        );
     }
 
     /// Tests deserialization of `Map(String, Int32)` with non-nullable key-value pairs.

--- a/clickhouse-arrow/src/arrow/deserialize/list.rs
+++ b/clickhouse-arrow/src/arrow/deserialize/list.rs
@@ -386,9 +386,10 @@ mod tests {
         assert_eq!(list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<_>>(), vec![0, 2, 3, 5]);
-        assert_eq!(list_array.nulls().unwrap().iter().collect::<Vec<bool>>(), vec![
-            true, false, true
-        ]);
+        assert_eq!(
+            list_array.nulls().unwrap().iter().collect::<Vec<bool>>(),
+            vec![true, false, true]
+        );
     }
 
     #[tokio::test]
@@ -600,9 +601,10 @@ mod tests {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -658,9 +660,10 @@ mod tests {
         assert_eq!(inner_list_array.len(), 5);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3, 5]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 2, 3, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 2, 3, 3, 5]
+        );
         assert_eq!(
             inner_list_array.nulls().unwrap().iter().collect::<Vec<bool>>(),
             vec![true, false, true, false, true] // 0=non-null, 1=null
@@ -716,9 +719,10 @@ mod tests {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -769,9 +773,10 @@ mod tests {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &StringArray::from(vec!["a", "b", "c", "d", "e"]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -888,9 +893,10 @@ mod tests {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &StringArray::from(vec![Some("a"), None, Some("c"), None, Some("e")]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -1169,9 +1175,10 @@ mod tests {
 
         assert_eq!(list_array.len(), rows);
 
-        assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 2, 4, 7, 8
-        ]);
+        assert_eq!(
+            list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 2, 4, 7, 8]
+        );
         assert_eq!(list_array.nulls(), None);
         let expected_keys = Int32Array::from(vec![
             Some(1),
@@ -1277,9 +1284,10 @@ mod tests_sync {
         assert_eq!(list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<_>>(), vec![0, 2, 3, 5]);
-        assert_eq!(list_array.nulls().unwrap().iter().collect::<Vec<bool>>(), vec![
-            true, false, true
-        ]);
+        assert_eq!(
+            list_array.nulls().unwrap().iter().collect::<Vec<bool>>(),
+            vec![true, false, true]
+        );
     }
 
     #[test]
@@ -1430,9 +1438,10 @@ mod tests_sync {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -1476,9 +1485,10 @@ mod tests_sync {
         assert_eq!(inner_list_array.len(), 5);
         assert_eq!(values, &Int32Array::from(vec![1, 2, 3, 4, 5]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3, 5]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 2, 3, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 2, 3, 3, 5]
+        );
         assert_eq!(
             inner_list_array.nulls().unwrap().iter().collect::<Vec<bool>>(),
             vec![true, false, true, false, true] // 0=non-null, 1=null
@@ -1522,9 +1532,10 @@ mod tests_sync {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -1563,9 +1574,10 @@ mod tests_sync {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &StringArray::from(vec!["a", "b", "c", "d", "e"]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -1657,9 +1669,10 @@ mod tests_sync {
         assert_eq!(inner_list_array.len(), 3);
         assert_eq!(values, &StringArray::from(vec![Some("a"), None, Some("c"), None, Some("e")]));
         assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![0, 2, 3]);
-        assert_eq!(inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 3, 5
-        ]);
+        assert_eq!(
+            inner_list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 3, 5]
+        );
         assert_eq!(list_array.nulls(), None);
     }
 
@@ -1866,9 +1879,10 @@ mod tests_sync {
 
         assert_eq!(list_array.len(), rows);
 
-        assert_eq!(list_array.offsets().iter().copied().collect::<Vec<i32>>(), vec![
-            0, 2, 2, 4, 7, 8
-        ]);
+        assert_eq!(
+            list_array.offsets().iter().copied().collect::<Vec<i32>>(),
+            vec![0, 2, 2, 4, 7, 8]
+        );
         assert_eq!(list_array.nulls(), None);
         let expected_keys = Int32Array::from(vec![
             Some(1),

--- a/clickhouse-arrow/src/arrow/serialize.rs
+++ b/clickhouse-arrow/src/arrow/serialize.rs
@@ -295,11 +295,14 @@ mod tests {
             .unwrap();
 
         let output = buffer.into_inner();
-        assert_eq!(output, vec![
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-        ]);
+        assert_eq!(
+            output,
+            vec![
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+            ]
+        );
     }
 
     /// Tests serialization of `Nullable(Int32)` array with nulls.
@@ -315,13 +318,16 @@ mod tests {
             .unwrap();
 
         let output = buffer.into_inner();
-        assert_eq!(output, vec![
-            // Null mask: [0, 1, 0] (0=non-null, 1=null)
-            0, 1, 0, // Values: [1, 0, 3]
-            1, 0, 0, 0, // 1
-            0, 0, 0, 0, // null
-            3, 0, 0, 0, // 3
-        ]);
+        assert_eq!(
+            output,
+            vec![
+                // Null mask: [0, 1, 0] (0=non-null, 1=null)
+                0, 1, 0, // Values: [1, 0, 3]
+                1, 0, 0, 0, // 1
+                0, 0, 0, 0, // null
+                3, 0, 0, 0, // 3
+            ]
+        );
     }
 
     /// Tests serialization of `String` array.
@@ -337,11 +343,14 @@ mod tests {
             .unwrap();
 
         let output = buffer.into_inner();
-        assert_eq!(output, vec![
-            5, b'h', b'e', b'l', b'l', b'o', // "hello"
-            0,    // ""
-            5, b'w', b'o', b'r', b'l', b'd', // "world"
-        ]);
+        assert_eq!(
+            output,
+            vec![
+                5, b'h', b'e', b'l', b'l', b'o', // "hello"
+                0,    // ""
+                5, b'w', b'o', b'r', b'l', b'd', // "world"
+            ]
+        );
     }
 
     /// Tests serialization of `Nullable(String)` array with nulls.
@@ -357,13 +366,16 @@ mod tests {
             .unwrap();
 
         let output = buffer.into_inner();
-        assert_eq!(output, vec![
-            // Null mask: [0, 1, 0]
-            0, 1, 0, // Values: ["a", "", "c"]
-            1, b'a', // "a"
-            0,    // null (empty string)
-            1, b'c', // "c"
-        ]);
+        assert_eq!(
+            output,
+            vec![
+                // Null mask: [0, 1, 0]
+                0, 1, 0, // Values: ["a", "", "c"]
+                1, b'a', // "a"
+                0,    // null (empty string)
+                1, b'c', // "c"
+            ]
+        );
     }
 
     /// Tests serialization of `Array(Int32)` with non-nullable inner values.
@@ -383,18 +395,21 @@ mod tests {
             .unwrap();
 
         let output = buffer.into_inner();
-        assert_eq!(output, vec![
-            // Offsets: [2, 3, 5] (skipping first 0)
-            2, 0, 0, 0, 0, 0, 0, 0, // 2
-            3, 0, 0, 0, 0, 0, 0, 0, // 3
-            5, 0, 0, 0, 0, 0, 0, 0, // 5
-            // Values: [1, 2, 3, 4, 5]
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-            4, 0, 0, 0, // 4
-            5, 0, 0, 0, // 5
-        ]);
+        assert_eq!(
+            output,
+            vec![
+                // Offsets: [2, 3, 5] (skipping first 0)
+                2, 0, 0, 0, 0, 0, 0, 0, // 2
+                3, 0, 0, 0, 0, 0, 0, 0, // 3
+                5, 0, 0, 0, 0, 0, 0, 0, // 5
+                // Values: [1, 2, 3, 4, 5]
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+                4, 0, 0, 0, // 4
+                5, 0, 0, 0, // 5
+            ]
+        );
     }
 
     /// Tests serialization of `Nullable(Array(Int32))` with null arrays.
@@ -416,18 +431,21 @@ mod tests {
             .unwrap();
 
         let output = buffer.into_inner();
-        assert_eq!(output, vec![
-            // Null mask: [] (0=non-null, 1=null)
-            2, 0, 0, 0, 0, 0, 0, 0, // 2
-            2, 0, 0, 0, 0, 0, 0, 0, // 2 (null)
-            5, 0, 0, 0, 0, 0, 0, 0, // 5
-            // Values: [1, 2, 3, 4, 5]
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-            4, 0, 0, 0, // 4
-            5, 0, 0, 0, // 5
-        ]);
+        assert_eq!(
+            output,
+            vec![
+                // Null mask: [] (0=non-null, 1=null)
+                2, 0, 0, 0, 0, 0, 0, 0, // 2
+                2, 0, 0, 0, 0, 0, 0, 0, // 2 (null)
+                5, 0, 0, 0, 0, 0, 0, 0, // 5
+                // Values: [1, 2, 3, 4, 5]
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+                4, 0, 0, 0, // 4
+                5, 0, 0, 0, // 5
+            ]
+        );
     }
 
     /// Tests serialization of `Map(String, Int32)` with non-nullable key-value pairs.
@@ -459,24 +477,27 @@ mod tests {
             .unwrap();
 
         let output = buffer.into_inner();
-        assert_eq!(output, vec![
-            // Offsets: [2, 3, 5] (skipping first 0)
-            2, 0, 0, 0, 0, 0, 0, 0, // 2
-            3, 0, 0, 0, 0, 0, 0, 0, // 3
-            5, 0, 0, 0, 0, 0, 0, 0, // 5
-            // Keys: ["a", "b", "c", "d", "e"]
-            1, b'a', // "a"
-            1, b'b', // "b"
-            1, b'c', // "c"
-            1, b'd', // "d"
-            1, b'e', // "e"
-            // Values: [1, 2, 3, 4, 5]
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-            4, 0, 0, 0, // 4
-            5, 0, 0, 0, // 5
-        ]);
+        assert_eq!(
+            output,
+            vec![
+                // Offsets: [2, 3, 5] (skipping first 0)
+                2, 0, 0, 0, 0, 0, 0, 0, // 2
+                3, 0, 0, 0, 0, 0, 0, 0, // 3
+                5, 0, 0, 0, 0, 0, 0, 0, // 5
+                // Keys: ["a", "b", "c", "d", "e"]
+                1, b'a', // "a"
+                1, b'b', // "b"
+                1, b'c', // "c"
+                1, b'd', // "d"
+                1, b'e', // "e"
+                // Values: [1, 2, 3, 4, 5]
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+                4, 0, 0, 0, // 4
+                5, 0, 0, 0, // 5
+            ]
+        );
     }
 
     /// Tests serialization of `Int32` array with zero rows.
@@ -793,11 +814,14 @@ mod tests_sync {
 
         Type::Int32.serialize(&mut buffer, &column, &DataType::Int32, &mut state).unwrap();
 
-        assert_eq!(buffer, vec![
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-        ]);
+        assert_eq!(
+            buffer,
+            vec![
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+            ]
+        );
     }
 
     /// Tests serialization of `Nullable(Int32)` array with nulls.
@@ -811,13 +835,16 @@ mod tests_sync {
             .serialize(&mut buffer, &column, &DataType::Int32, &mut state)
             .unwrap();
 
-        assert_eq!(buffer, vec![
-            // Null mask: [0, 1, 0] (0=non-null, 1=null)
-            0, 1, 0, // Values: [1, 0, 3]
-            1, 0, 0, 0, // 1
-            0, 0, 0, 0, // null
-            3, 0, 0, 0, // 3
-        ]);
+        assert_eq!(
+            buffer,
+            vec![
+                // Null mask: [0, 1, 0] (0=non-null, 1=null)
+                0, 1, 0, // Values: [1, 0, 3]
+                1, 0, 0, 0, // 1
+                0, 0, 0, 0, // null
+                3, 0, 0, 0, // 3
+            ]
+        );
     }
 
     /// Tests serialization of `String` array.
@@ -829,11 +856,14 @@ mod tests_sync {
 
         Type::String.serialize(&mut buffer, &column, &DataType::Utf8, &mut state).unwrap();
 
-        assert_eq!(buffer, vec![
-            5, b'h', b'e', b'l', b'l', b'o', // "hello"
-            0,    // ""
-            5, b'w', b'o', b'r', b'l', b'd', // "world"
-        ]);
+        assert_eq!(
+            buffer,
+            vec![
+                5, b'h', b'e', b'l', b'l', b'o', // "hello"
+                0,    // ""
+                5, b'w', b'o', b'r', b'l', b'd', // "world"
+            ]
+        );
     }
 
     /// Tests serialization of `Nullable(String)` array with nulls.
@@ -847,13 +877,16 @@ mod tests_sync {
             .serialize(&mut buffer, &column, &DataType::Utf8, &mut state)
             .unwrap();
 
-        assert_eq!(buffer, vec![
-            // Null mask: [0, 1, 0]
-            0, 1, 0, // Values: ["a", "", "c"]
-            1, b'a', // "a"
-            0,    // null (empty string)
-            1, b'c', // "c"
-        ]);
+        assert_eq!(
+            buffer,
+            vec![
+                // Null mask: [0, 1, 0]
+                0, 1, 0, // Values: ["a", "", "c"]
+                1, b'a', // "a"
+                0,    // null (empty string)
+                1, b'c', // "c"
+            ]
+        );
     }
 
     /// Tests serialization of `Array(Int32)` with non-nullable inner values.
@@ -871,18 +904,21 @@ mod tests_sync {
             .serialize(&mut buffer, &column, &DataType::List(inner_field), &mut state)
             .unwrap();
 
-        assert_eq!(buffer, vec![
-            // Offsets: [2, 3, 5] (skipping first 0)
-            2, 0, 0, 0, 0, 0, 0, 0, // 2
-            3, 0, 0, 0, 0, 0, 0, 0, // 3
-            5, 0, 0, 0, 0, 0, 0, 0, // 5
-            // Values: [1, 2, 3, 4, 5]
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-            4, 0, 0, 0, // 4
-            5, 0, 0, 0, // 5
-        ]);
+        assert_eq!(
+            buffer,
+            vec![
+                // Offsets: [2, 3, 5] (skipping first 0)
+                2, 0, 0, 0, 0, 0, 0, 0, // 2
+                3, 0, 0, 0, 0, 0, 0, 0, // 3
+                5, 0, 0, 0, 0, 0, 0, 0, // 5
+                // Values: [1, 2, 3, 4, 5]
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+                4, 0, 0, 0, // 4
+                5, 0, 0, 0, // 5
+            ]
+        );
     }
 
     /// Tests serialization of `Nullable(Array(Int32))` with null arrays.
@@ -902,19 +938,22 @@ mod tests_sync {
             .serialize(&mut buffer, &column, field.data_type(), &mut state)
             .unwrap();
 
-        assert_eq!(buffer, vec![
-            // Null mask: []
-            // Offsets: [2, 2, 5] (skipping first 0, null array repeats offset)
-            2, 0, 0, 0, 0, 0, 0, 0, // 2
-            2, 0, 0, 0, 0, 0, 0, 0, // 2 (null)
-            5, 0, 0, 0, 0, 0, 0, 0, // 5
-            // Values: [1, 2, 3, 4, 5]
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-            4, 0, 0, 0, // 4
-            5, 0, 0, 0, // 5
-        ]);
+        assert_eq!(
+            buffer,
+            vec![
+                // Null mask: []
+                // Offsets: [2, 2, 5] (skipping first 0, null array repeats offset)
+                2, 0, 0, 0, 0, 0, 0, 0, // 2
+                2, 0, 0, 0, 0, 0, 0, 0, // 2 (null)
+                5, 0, 0, 0, 0, 0, 0, 0, // 5
+                // Values: [1, 2, 3, 4, 5]
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+                4, 0, 0, 0, // 4
+                5, 0, 0, 0, // 5
+            ]
+        );
     }
 
     /// Tests serialization of `Map(String, Int32)` with non-nullable key-value pairs.
@@ -944,24 +983,27 @@ mod tests_sync {
             .serialize(&mut buffer, &column, field.data_type(), &mut state)
             .unwrap();
 
-        assert_eq!(buffer, vec![
-            // Offsets: [2, 3, 5] (skipping first 0)
-            2, 0, 0, 0, 0, 0, 0, 0, // 2
-            3, 0, 0, 0, 0, 0, 0, 0, // 3
-            5, 0, 0, 0, 0, 0, 0, 0, // 5
-            // Keys: ["a", "b", "c", "d", "e"]
-            1, b'a', // "a"
-            1, b'b', // "b"
-            1, b'c', // "c"
-            1, b'd', // "d"
-            1, b'e', // "e"
-            // Values: [1, 2, 3, 4, 5]
-            1, 0, 0, 0, // 1
-            2, 0, 0, 0, // 2
-            3, 0, 0, 0, // 3
-            4, 0, 0, 0, // 4
-            5, 0, 0, 0, // 5
-        ]);
+        assert_eq!(
+            buffer,
+            vec![
+                // Offsets: [2, 3, 5] (skipping first 0)
+                2, 0, 0, 0, 0, 0, 0, 0, // 2
+                3, 0, 0, 0, 0, 0, 0, 0, // 3
+                5, 0, 0, 0, 0, 0, 0, 0, // 5
+                // Keys: ["a", "b", "c", "d", "e"]
+                1, b'a', // "a"
+                1, b'b', // "b"
+                1, b'c', // "c"
+                1, b'd', // "d"
+                1, b'e', // "e"
+                // Values: [1, 2, 3, 4, 5]
+                1, 0, 0, 0, // 1
+                2, 0, 0, 0, // 2
+                3, 0, 0, 0, // 3
+                4, 0, 0, 0, // 4
+                5, 0, 0, 0, // 5
+            ]
+        );
     }
 
     /// Tests serialization of `Int32` array with zero rows.

--- a/clickhouse-arrow/src/arrow/serialize/binary.rs
+++ b/clickhouse-arrow/src/arrow/serialize/binary.rs
@@ -323,10 +323,14 @@ put_fixed_values!(put_fixed_binary_values, [
 ]);
 
 /// Coerces a byte slice to itself (no-op).
-fn pass_through(v: &[u8]) -> &[u8] { v }
+fn pass_through(v: &[u8]) -> &[u8] {
+    v
+}
 
 /// Coerces a string to its byte representation.
-fn as_bytes(v: &str) -> &[u8] { v.as_bytes() }
+fn as_bytes(v: &str) -> &[u8] {
+    v.as_bytes()
+}
 
 #[cfg(test)]
 mod tests {

--- a/clickhouse-arrow/src/arrow/serialize/list.rs
+++ b/clickhouse-arrow/src/arrow/serialize/list.rs
@@ -241,7 +241,9 @@ mod tests {
 
     type MockWriter = Vec<u8>;
 
-    fn wrap_array(typ: Type) -> Type { Type::Array(Box::new(typ)) }
+    fn wrap_array(typ: Type) -> Type {
+        Type::Array(Box::new(typ))
+    }
 
     /// Helper function used by individual type serializers
     pub(crate) async fn test_type_serializer(
@@ -518,7 +520,9 @@ mod tests_sync {
 
     type MockWriter = Vec<u8>;
 
-    fn wrap_array(typ: Type) -> Type { Type::Array(Box::new(typ)) }
+    fn wrap_array(typ: Type) -> Type {
+        Type::Array(Box::new(typ))
+    }
 
     /// Helper function used by individual type serializers
     #[expect(clippy::needless_pass_by_value)]

--- a/clickhouse-arrow/src/arrow/serialize/low_cardinality.rs
+++ b/clickhouse-arrow/src/arrow/serialize/low_cardinality.rs
@@ -465,8 +465,12 @@ async fn write_string_values<W: ClickHouseWrite>(
     state: &mut SerializerState,
 ) -> Result<()> {
     // Helper functions for macro
-    fn bytes(v: &str) -> &[u8] { v.as_bytes() }
-    fn passthrough(v: &[u8]) -> &[u8] { v }
+    fn bytes(v: &str) -> &[u8] {
+        v.as_bytes()
+    }
+    fn passthrough(v: &[u8]) -> &[u8] {
+        v
+    }
 
     // Handle string-like array
     let mut dict = Vec::with_capacity(64.min(values.len()));
@@ -559,8 +563,12 @@ fn put_string_values<W: ClickHouseBytesWrite>(
     state: &mut SerializerState,
 ) -> Result<()> {
     // Helper functions for macro
-    fn bytes(v: &str) -> &[u8] { v.as_bytes() }
-    fn passthrough(v: &[u8]) -> &[u8] { v }
+    fn bytes(v: &str) -> &[u8] {
+        v.as_bytes()
+    }
+    fn passthrough(v: &[u8]) -> &[u8] {
+        v
+    }
 
     // Handle string-like array
     let mut dict = Vec::with_capacity(64.min(values.len()));

--- a/clickhouse-arrow/src/arrow/serialize/primitive.rs
+++ b/clickhouse-arrow/src/arrow/serialize/primitive.rs
@@ -931,11 +931,12 @@ macro_rules! put_float_values {
 }
 
 write_float_values!(write_f32_values, f32, write_u32_le, [Float32Array, Float16Array]);
-write_float_values!(write_f64_values, f64, write_u64_le, [
-    Float64Array,
-    Float32Array,
-    Float16Array
-]);
+write_float_values!(
+    write_f64_values,
+    f64,
+    write_u64_le,
+    [Float64Array, Float32Array, Float16Array]
+);
 
 put_float_values!(put_f32_values, f32, put_u32_le, [Float32Array, Float16Array]);
 put_float_values!(put_f64_values, f64, put_u64_le, [Float64Array, Float32Array, Float16Array]);

--- a/clickhouse-arrow/src/arrow/serialize/tuple.rs
+++ b/clickhouse-arrow/src/arrow/serialize/tuple.rs
@@ -113,7 +113,9 @@ mod tests {
 
     type MockWriter = Vec<u8>;
 
-    fn wrap_tuple(inner: Vec<Type>) -> Type { Type::Tuple(inner) }
+    fn wrap_tuple(inner: Vec<Type>) -> Type {
+        Type::Tuple(inner)
+    }
 
     #[tokio::test]
     async fn test_serialize_tuple_int32_string() {
@@ -321,7 +323,9 @@ mod tests_sync {
 
     type MockWriter = Vec<u8>;
 
-    fn wrap_tuple(inner: Vec<Type>) -> Type { Type::Tuple(inner) }
+    fn wrap_tuple(inner: Vec<Type>) -> Type {
+        Type::Tuple(inner)
+    }
 
     #[test]
     fn test_serialize_tuple_int32_string() {

--- a/clickhouse-arrow/src/arrow/types.rs
+++ b/clickhouse-arrow/src/arrow/types.rs
@@ -223,6 +223,8 @@ pub(crate) fn arrow_to_ch_type(
         DataType::UInt64 => Type::UInt64,
         DataType::Float32 => Type::Float32,
         DataType::Float64 => Type::Float64,
+        DataType::Decimal32(_, s) => Type::Decimal32(*s as usize),
+        DataType::Decimal64(_, s) => Type::Decimal64(*s as usize),
         DataType::Decimal128(p, s) => match *p {
             p if p <= 9 => Type::Decimal32(*s as usize),
             p if p <= 18 => Type::Decimal64(*s as usize),

--- a/clickhouse-arrow/src/arrow/utils.rs
+++ b/clickhouse-arrow/src/arrow/utils.rs
@@ -785,22 +785,20 @@ mod tests {
     fn test_utf8_array() {
         let array = StringArray::from(vec![Some("hello"), None, Some("world")]);
         let result = array_to_values(&array, &DataType::Utf8, None).unwrap();
-        assert_eq!(result, vec![
-            Value::String(b"hello".to_vec()),
-            Value::Null,
-            Value::String(b"world".to_vec()),
-        ]);
+        assert_eq!(
+            result,
+            vec![Value::String(b"hello".to_vec()), Value::Null, Value::String(b"world".to_vec()),]
+        );
     }
 
     #[test]
     fn test_binary_array_values() {
         let array = BinaryArray::from(vec![Some(b"abc".as_ref()), None, Some(b"def".as_ref())]);
         let result = array_to_values(&array, &DataType::Binary, None).unwrap();
-        assert_eq!(result, vec![
-            Value::String(b"abc".to_vec()),
-            Value::Null,
-            Value::String(b"def".to_vec()),
-        ]);
+        assert_eq!(
+            result,
+            vec![Value::String(b"abc".to_vec()), Value::Null, Value::String(b"def".to_vec()),]
+        );
     }
 
     #[test]
@@ -838,10 +836,13 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(result, vec![
-            Value::Array(vec![Value::Int32(1), Value::Int32(2)]),
-            Value::Array(vec![Value::Int32(3), Value::Int32(4)]),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Array(vec![Value::Int32(1), Value::Int32(2)]),
+                Value::Array(vec![Value::Int32(3), Value::Int32(4)]),
+            ]
+        );
     }
 
     #[test]
@@ -862,10 +863,13 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(result, vec![
-            Value::Array(vec![Value::Int32(1), Value::Int32(2)]),
-            Value::Array(vec![Value::Int32(3), Value::Int32(4)]),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Array(vec![Value::Int32(1), Value::Int32(2)]),
+                Value::Array(vec![Value::Int32(3), Value::Int32(4)]),
+            ]
+        );
     }
 
     #[test]
@@ -902,11 +906,10 @@ mod tests {
             Some(&Type::Enum8(pairs.clone())),
         )
         .unwrap();
-        assert_eq!(result, vec![
-            Value::Enum8("a".to_string(), 1),
-            Value::Null,
-            Value::Enum8("b".to_string(), 2),
-        ]);
+        assert_eq!(
+            result,
+            vec![Value::Enum8("a".to_string(), 1), Value::Null, Value::Enum8("b".to_string(), 2),]
+        );
     }
 
     #[test]
@@ -923,11 +926,14 @@ mod tests {
             Some(&Type::Enum16(pairs.clone())),
         )
         .unwrap();
-        assert_eq!(result, vec![
-            Value::Enum16("x".to_string(), 10),
-            Value::Null,
-            Value::Enum16("y".to_string(), 20),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Enum16("x".to_string(), 10),
+                Value::Null,
+                Value::Enum16("y".to_string(), 20),
+            ]
+        );
     }
 
     #[test]
@@ -945,10 +951,13 @@ mod tests {
         )]);
         let fields = Fields::from_iter(vec![outer_field]);
         let result = array_to_values(&outer_struct_array, &DataType::Struct(fields), None).unwrap();
-        assert_eq!(result, vec![
-            Value::Tuple(vec![Value::Tuple(vec![Value::Int32(1)])]),
-            Value::Tuple(vec![Value::Tuple(vec![Value::Int32(2)])]),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Tuple(vec![Value::Tuple(vec![Value::Int32(1)])]),
+                Value::Tuple(vec![Value::Tuple(vec![Value::Int32(2)])]),
+            ]
+        );
     }
 
     #[test]
@@ -959,11 +968,14 @@ mod tests {
         let result =
             array_to_values(&array, &DataType::Timestamp(TimeUnit::Second, Some(tz)), None)
                 .unwrap();
-        assert_eq!(result, vec![
-            Value::DateTime(DateTime(Tz::America__New_York, 1_625_097_600)),
-            Value::Null,
-            Value::DateTime(DateTime(Tz::America__New_York, 1_625_184_000)),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::DateTime(DateTime(Tz::America__New_York, 1_625_097_600)),
+                Value::Null,
+                Value::DateTime(DateTime(Tz::America__New_York, 1_625_184_000)),
+            ]
+        );
     }
 
     // Cross-type conversion tests
@@ -995,10 +1007,10 @@ mod tests {
         )
         .unwrap();
         let result = array_to_values(&array, &DataType::FixedSizeBinary(5), None).unwrap();
-        assert_eq!(result, vec![
-            Value::String(b"abcde".to_vec()),
-            Value::String(b"fghij".to_vec()),
-        ]);
+        assert_eq!(
+            result,
+            vec![Value::String(b"abcde".to_vec()), Value::String(b"fghij".to_vec()),]
+        );
     }
 
     #[test]
@@ -1101,29 +1113,38 @@ mod tests {
     fn test_date64_array() {
         let array = Date64Array::from(vec![Some(0), None, Some(1)]);
         let result = array_to_values(&array, &DataType::Date64, None).unwrap();
-        assert_eq!(result, vec![
-            Value::DateTime64(DynDateTime64(Tz::UTC, 0, 3)),
-            Value::Null,
-            Value::DateTime64(DynDateTime64(Tz::UTC, 1, 3)),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::DateTime64(DynDateTime64(Tz::UTC, 0, 3)),
+                Value::Null,
+                Value::DateTime64(DynDateTime64(Tz::UTC, 1, 3)),
+            ]
+        );
 
         // With timezone
         let typ = Type::DateTime64(3, Tz::America__New_York);
         let result = array_to_values(&array, &DataType::Date64, Some(&typ)).unwrap();
-        assert_eq!(result, vec![
-            Value::DateTime64(DynDateTime64(Tz::America__New_York, 0, 3)),
-            Value::Null,
-            Value::DateTime64(DynDateTime64(Tz::America__New_York, 1, 3)),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::DateTime64(DynDateTime64(Tz::America__New_York, 0, 3)),
+                Value::Null,
+                Value::DateTime64(DynDateTime64(Tz::America__New_York, 1, 3)),
+            ]
+        );
 
         // With timezone default
         let typ = Type::Date;
         let result = array_to_values(&array, &DataType::Date64, Some(&typ)).unwrap();
-        assert_eq!(result, vec![
-            Value::DateTime64(DynDateTime64(Tz::UTC, 0, 3)),
-            Value::Null,
-            Value::DateTime64(DynDateTime64(Tz::UTC, 1, 3)),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::DateTime64(DynDateTime64(Tz::UTC, 0, 3)),
+                Value::Null,
+                Value::DateTime64(DynDateTime64(Tz::UTC, 1, 3)),
+            ]
+        );
     }
 
     #[test]
@@ -1132,11 +1153,14 @@ mod tests {
             TimestampSecondArray::from(vec![Some(1_625_097_600), None, Some(1_625_184_000)]);
         let result =
             array_to_values(&array, &DataType::Timestamp(TimeUnit::Second, None), None).unwrap();
-        assert_eq!(result, vec![
-            Value::DateTime(DateTime(chrono_tz::UTC, 1_625_097_600)),
-            Value::Null,
-            Value::DateTime(DateTime(chrono_tz::UTC, 1_625_184_000)),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::DateTime(DateTime(chrono_tz::UTC, 1_625_097_600)),
+                Value::Null,
+                Value::DateTime(DateTime(chrono_tz::UTC, 1_625_184_000)),
+            ]
+        );
     }
 
     #[test]
@@ -1156,10 +1180,13 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(result, vec![
-            Value::Array(vec![Value::Int32(1), Value::Int32(2)]),
-            Value::Array(vec![Value::Int32(3), Value::Int32(4)]),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Array(vec![Value::Int32(1), Value::Int32(2)]),
+                Value::Array(vec![Value::Int32(3), Value::Int32(4)]),
+            ]
+        );
     }
 
     #[test]
@@ -1172,10 +1199,13 @@ mod tests {
         ]);
         let fields = Fields::from_iter(vec![int_field, str_field]);
         let result = array_to_values(&struct_array, &DataType::Struct(fields), None).unwrap();
-        assert_eq!(result, vec![
-            Value::Tuple(vec![Value::Int32(1), Value::String(b"x".to_vec())]),
-            Value::Tuple(vec![Value::Int32(2), Value::String(b"y".to_vec())]),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Tuple(vec![Value::Int32(1), Value::String(b"x".to_vec())]),
+                Value::Tuple(vec![Value::Int32(2), Value::String(b"y".to_vec())]),
+            ]
+        );
     }
 
     #[test]
@@ -1191,10 +1221,13 @@ mod tests {
         ]);
         let fields = Fields::from_iter(vec![int_field, str_field]);
         let result = array_to_values(&struct_array, &DataType::Struct(fields), None).unwrap();
-        assert_eq!(result, vec![
-            Value::Tuple(vec![Value::Int32(1), Value::String(b"x".to_vec())]),
-            Value::Tuple(vec![Value::Int32(2), Value::Null]),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Tuple(vec![Value::Int32(1), Value::String(b"x".to_vec())]),
+                Value::Tuple(vec![Value::Int32(2), Value::Null]),
+            ]
+        );
     }
 
     #[test]
@@ -1242,10 +1275,13 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(result, vec![
-            Value::Map(vec![Value::String(b"k1".to_vec())], vec![Value::Int32(10)]),
-            Value::Map(vec![Value::String(b"k2".to_vec())], vec![Value::Int32(20)]),
-        ]);
+        assert_eq!(
+            result,
+            vec![
+                Value::Map(vec![Value::String(b"k1".to_vec())], vec![Value::Int32(10)]),
+                Value::Map(vec![Value::String(b"k2".to_vec())], vec![Value::Int32(20)]),
+            ]
+        );
     }
 
     #[test]
@@ -1262,11 +1298,10 @@ mod tests {
             None,
         )
         .unwrap();
-        assert_eq!(result, vec![
-            Value::String(b"hello".to_vec()),
-            Value::Null,
-            Value::String(b"world".to_vec()),
-        ]);
+        assert_eq!(
+            result,
+            vec![Value::String(b"hello".to_vec()), Value::Null, Value::String(b"world".to_vec()),]
+        );
     }
 
     #[test]
@@ -1303,31 +1338,34 @@ mod tests {
             Field::new("v_14", DataType::Utf8, false),
         ]));
         let str_vals = vec!["a", "b", "c"];
-        let batch = RecordBatch::try_new(schema, vec![
-            Arc::new(Int8Array::from(vec![1, 2, 3])),
-            Arc::new(Int16Array::from(vec![1, 2, 3])),
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
-            Arc::new(Int64Array::from(vec![1, 2, 3])),
-            Arc::new(UInt8Array::from(vec![1, 2, 3])),
-            Arc::new(UInt16Array::from(vec![1, 2, 3])),
-            Arc::new(UInt32Array::from(vec![1, 2, 3])),
-            Arc::new(UInt64Array::from(vec![1, 2, 3])),
-            Arc::new(Float32Array::from(vec![1.0_f32, 2.0, 3.0])),
-            Arc::new(Float64Array::from(vec![1.0_f64, 2.0, 3.0])),
-            Arc::new(TimestampSecondArray::from(vec![1, 2, 3])),
-            Arc::new(TimestampMillisecondArray::from(vec![1000, 2 * 1000, 3 * 1000])),
-            Arc::new(TimestampMicrosecondArray::from(vec![
-                1_000_000,
-                2 * 1_000_000,
-                3 * 1_000_000,
-            ])),
-            Arc::new(TimestampNanosecondArray::from(vec![
-                1_000_000_000,
-                2 * 1_000_000_000,
-                3 * 1_000_000_000,
-            ])),
-            Arc::new(StringArray::from(str_vals.clone())),
-        ])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int8Array::from(vec![1, 2, 3])),
+                Arc::new(Int16Array::from(vec![1, 2, 3])),
+                Arc::new(Int32Array::from(vec![1, 2, 3])),
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+                Arc::new(UInt8Array::from(vec![1, 2, 3])),
+                Arc::new(UInt16Array::from(vec![1, 2, 3])),
+                Arc::new(UInt32Array::from(vec![1, 2, 3])),
+                Arc::new(UInt64Array::from(vec![1, 2, 3])),
+                Arc::new(Float32Array::from(vec![1.0_f32, 2.0, 3.0])),
+                Arc::new(Float64Array::from(vec![1.0_f64, 2.0, 3.0])),
+                Arc::new(TimestampSecondArray::from(vec![1, 2, 3])),
+                Arc::new(TimestampMillisecondArray::from(vec![1000, 2 * 1000, 3 * 1000])),
+                Arc::new(TimestampMicrosecondArray::from(vec![
+                    1_000_000,
+                    2 * 1_000_000,
+                    3 * 1_000_000,
+                ])),
+                Arc::new(TimestampNanosecondArray::from(vec![
+                    1_000_000_000,
+                    2 * 1_000_000_000,
+                    3 * 1_000_000_000,
+                ])),
+                Arc::new(StringArray::from(str_vals.clone())),
+            ],
+        )
         .unwrap();
 
         let result = batch_to_rows(&batch, None).unwrap().collect::<Vec<_>>();
@@ -1339,23 +1377,26 @@ mod tests {
         for (i, row) in result.into_iter().enumerate() {
             let row = row.unwrap();
             let seed = i + 1;
-            assert_eq!(row, vec![
-                Value::Int8(seed as i8),
-                Value::Int16(seed as i16),
-                Value::Int32(seed as i32),
-                Value::Int64(seed as i64),
-                Value::UInt8(seed as u8),
-                Value::UInt16(seed as u16),
-                Value::UInt32(seed as u32),
-                Value::UInt64(seed as u64),
-                Value::Float32(seed as f32),
-                Value::Float64(seed as f64),
-                Value::DateTime(DateTime(Tz::UTC, seed as u32)),
-                Value::DateTime64(DynDateTime64(Tz::UTC, seed as u64 * 1000, 3)),
-                Value::DateTime64(DynDateTime64(Tz::UTC, seed as u64 * 1_000_000, 6)),
-                Value::DateTime64(DynDateTime64(Tz::UTC, seed as u64 * 1_000_000_000, 9)),
-                Value::String(str_vals[i].as_bytes().to_vec())
-            ]);
+            assert_eq!(
+                row,
+                vec![
+                    Value::Int8(seed as i8),
+                    Value::Int16(seed as i16),
+                    Value::Int32(seed as i32),
+                    Value::Int64(seed as i64),
+                    Value::UInt8(seed as u8),
+                    Value::UInt16(seed as u16),
+                    Value::UInt32(seed as u32),
+                    Value::UInt64(seed as u64),
+                    Value::Float32(seed as f32),
+                    Value::Float64(seed as f64),
+                    Value::DateTime(DateTime(Tz::UTC, seed as u32)),
+                    Value::DateTime64(DynDateTime64(Tz::UTC, seed as u64 * 1000, 3)),
+                    Value::DateTime64(DynDateTime64(Tz::UTC, seed as u64 * 1_000_000, 6)),
+                    Value::DateTime64(DynDateTime64(Tz::UTC, seed as u64 * 1_000_000_000, 9)),
+                    Value::String(str_vals[i].as_bytes().to_vec())
+                ]
+            );
         }
     }
 
@@ -1365,20 +1406,23 @@ mod tests {
             Field::new("id", DataType::Int32, true),
             Field::new("name", DataType::Utf8, true),
         ]));
-        let batch = RecordBatch::try_new(schema, vec![
-            Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])),
-            Arc::new(StringArray::from(vec![Some("a"), Some("b"), None])),
-        ])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![Some(1), None, Some(3)])),
+                Arc::new(StringArray::from(vec![Some("a"), Some("b"), None])),
+            ],
+        )
         .unwrap();
 
         let mut result = batch_to_rows(&batch, None).unwrap().collect::<Vec<_>>();
         assert_eq!(result.len(), 3);
         assert_eq!(result.pop().unwrap().unwrap(), vec![Value::Int32(3), Value::Null]);
         assert_eq!(result.pop().unwrap().unwrap(), vec![Value::Null, Value::String(b"b".to_vec())]);
-        assert_eq!(result.pop().unwrap().unwrap(), vec![
-            Value::Int32(1),
-            Value::String(b"a".to_vec())
-        ]);
+        assert_eq!(
+            result.pop().unwrap().unwrap(),
+            vec![Value::Int32(1), Value::String(b"a".to_vec())]
+        );
     }
 
     #[test]
@@ -1387,12 +1431,15 @@ mod tests {
             Arc::new(Schema::new(vec![Field::new("uuid", DataType::FixedSizeBinary(16), false)]));
         let uuid1 = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let uuid2 = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440001").unwrap();
-        let batch = RecordBatch::try_new(schema, vec![Arc::new(
-            FixedSizeBinaryArray::try_from_iter(
-                vec![uuid1.as_bytes(), uuid2.as_bytes()].into_iter(),
-            )
-            .unwrap(),
-        )])
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![Arc::new(
+                FixedSizeBinaryArray::try_from_iter(
+                    vec![uuid1.as_bytes(), uuid2.as_bytes()].into_iter(),
+                )
+                .unwrap(),
+            )],
+        )
         .unwrap();
 
         let type_hints = vec![("uuid".to_string(), Type::Uuid)];

--- a/clickhouse-arrow/src/client.rs
+++ b/clickhouse-arrow/src/client.rs
@@ -80,8 +80,8 @@ pub struct ConnectionContext {
 /// Emitted clickhouse events from the underlying connection
 #[derive(Debug, Clone)]
 pub struct Event {
-    pub event:     ClickHouseEvent,
-    pub qid:       Qid,
+    pub event: ClickHouseEvent,
+    pub qid: Qid,
     pub client_id: u16,
 }
 
@@ -134,9 +134,9 @@ pub enum ClickHouseEvent {
 #[derive(Clone, Debug)]
 pub struct Client<T: ClientFormat> {
     pub client_id: u16,
-    connection:    Arc<connection::Connection<T>>,
-    events:        Arc<broadcast::Sender<Event>>,
-    settings:      Option<Arc<Settings>>,
+    connection: Arc<connection::Connection<T>>,
+    events: Arc<broadcast::Sender<Event>>,
+    settings: Option<Arc<Settings>>,
 }
 
 impl<T: ClientFormat> Client<T> {
@@ -163,7 +163,9 @@ impl<T: ClientFormat> Client<T> {
     ///     .with_username("default")
     ///     .with_password("");
     /// ```
-    pub fn builder() -> ClientBuilder { ClientBuilder::new() }
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::new()
+    }
 
     /// Establishes a connection to a `ClickHouse` server over TCP, with optional TLS support.
     ///
@@ -277,7 +279,9 @@ impl<T: ClientFormat> Client<T> {
     /// let status = client.status();
     /// println!("Connection status: {status:?}");
     /// ```
-    pub fn status(&self) -> ConnectionStatus { self.connection.status() }
+    pub fn status(&self) -> ConnectionStatus {
+        self.connection.status()
+    }
 
     /// Subscribes to progress and profile events from `ClickHouse` queries.
     ///
@@ -310,7 +314,9 @@ impl<T: ClientFormat> Client<T> {
     /// // Execute a query to generate events
     /// client.query("SELECT * FROM large_table").await.unwrap();
     /// ```
-    pub fn subscribe_events(&self) -> broadcast::Receiver<Event> { self.events.subscribe() }
+    pub fn subscribe_events(&self) -> broadcast::Receiver<Event> {
+        self.events.subscribe()
+    }
 
     /// Checks the health of the underlying `ClickHouse` connection.
     ///

--- a/clickhouse-arrow/src/client/builder.rs
+++ b/clickhouse-arrow/src/client/builder.rs
@@ -47,10 +47,10 @@ use crate::{ArrowFormat, ClientOptions, Error, NativeFormat, Result};
 #[derive(Default, Debug, Clone)]
 pub struct ClientBuilder {
     destination: Option<Destination>,
-    options:     ClientOptions,
-    settings:    Option<Settings>,
-    context:     Option<ConnectionContext>,
-    verified:    bool,
+    options: ClientOptions,
+    settings: Option<Settings>,
+    context: Option<ConnectionContext>,
+    verified: bool,
 }
 
 impl ClientBuilder {
@@ -75,10 +75,10 @@ impl ClientBuilder {
     pub fn new() -> Self {
         ClientBuilder {
             destination: None,
-            options:     ClientOptions::default(),
-            settings:    None,
-            context:     None,
-            verified:    false,
+            options: ClientOptions::default(),
+            settings: None,
+            context: None,
+            verified: false,
         }
     }
 
@@ -102,7 +102,9 @@ impl ClientBuilder {
     ///     println!("Destination: {:?}", dest);
     /// }
     /// ```
-    pub fn destination(&self) -> Option<&Destination> { self.destination.as_ref() }
+    pub fn destination(&self) -> Option<&Destination> {
+        self.destination.as_ref()
+    }
 
     /// Retrieves the current connection options.
     ///
@@ -124,7 +126,9 @@ impl ClientBuilder {
     /// let options = builder.options();
     /// println!("Username: {}", options.username);
     /// ```
-    pub fn options(&self) -> &ClientOptions { &self.options }
+    pub fn options(&self) -> &ClientOptions {
+        &self.options
+    }
 
     /// Retrieves the configured session settings, if set.
     ///
@@ -149,7 +153,9 @@ impl ClientBuilder {
     ///     assert_eq!(config_settings, &settings)
     /// }
     /// ```
-    pub fn settings(&self) -> Option<&Settings> { self.settings.as_ref() }
+    pub fn settings(&self) -> Option<&Settings> {
+        self.settings.as_ref()
+    }
 
     /// Checks whether the builder's destination has been verified.
     ///
@@ -173,7 +179,9 @@ impl ClientBuilder {
     /// let verified_builder = builder.verify().await.unwrap();
     /// println!("Verified: {}", verified_builder.verified()); // true
     /// ```
-    pub fn verified(&self) -> bool { self.verified }
+    pub fn verified(&self) -> bool {
+        self.verified
+    }
 
     /// Sets the `ClickHouse` server address using a socket address.
     ///
@@ -198,7 +206,9 @@ impl ClientBuilder {
     ///     .with_socket_addr(addr);
     /// ```
     #[must_use]
-    pub fn with_socket_addr(self, addr: SocketAddr) -> Self { self.with_destination(addr) }
+    pub fn with_socket_addr(self, addr: SocketAddr) -> Self {
+        self.with_destination(addr)
+    }
 
     /// Sets the `ClickHouse` server address using a hostname and port.
     ///
@@ -994,7 +1004,9 @@ mod tests {
 
     use super::*;
 
-    fn default_builder() -> ClientBuilder { ClientBuilder::new() }
+    fn default_builder() -> ClientBuilder {
+        ClientBuilder::new()
+    }
 
     #[test]
     fn test_accessors_empty() {

--- a/clickhouse-arrow/src/client/chunk.rs
+++ b/clickhouse-arrow/src/client/chunk.rs
@@ -14,11 +14,13 @@ use crate::io::{ClickHouseRead, ClickHouseWrite};
 pub(super) struct ChunkWriter<W: ClickHouseWrite> {
     buffer: Vec<u8>,
     #[pin]
-    inner:  W,
+    inner: W,
 }
 
 impl<W: ClickHouseWrite> ChunkWriter<W> {
-    pub(super) fn new(inner: W) -> Self { Self { inner, buffer: Vec::new() } }
+    pub(super) fn new(inner: W) -> Self {
+        Self { inner, buffer: Vec::new() }
+    }
 
     pub(super) async fn finish_chunk(&mut self) -> io::Result<()> {
         let len = self.buffer.len();
@@ -67,12 +69,12 @@ impl<W: ClickHouseWrite> AsyncWrite for ChunkWriter<W> {
 #[pin_project]
 pub(crate) struct ChunkReader<R> {
     #[pin]
-    inner:       R,
-    state:       ReaderState,
-    buffer:      Vec<u8>, // Internal buffer for excess chunk data
+    inner: R,
+    state: ReaderState,
+    buffer: Vec<u8>,      // Internal buffer for excess chunk data
     read_buffer: Vec<u8>, // Internal buffer for reading chunk data
-    buffer_pos:  usize,   // Current position in the buffer
-    chunk_size:  u32,     // Remaining bytes in the current chunk
+    buffer_pos: usize,    // Current position in the buffer
+    chunk_size: u32,      // Remaining bytes in the current chunk
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/clickhouse-arrow/src/client/connection.rs
+++ b/clickhouse-arrow/src/client/connection.rs
@@ -45,14 +45,16 @@ impl From<u8> for ConnectionStatus {
 }
 
 impl From<ConnectionStatus> for u8 {
-    fn from(value: ConnectionStatus) -> u8 { value as u8 }
+    fn from(value: ConnectionStatus) -> u8 {
+        value as u8
+    }
 }
 
 /// Client metadata passed around the internal client
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ClientMetadata {
-    pub(crate) client_id:     u16,
-    pub(crate) compression:   CompressionMethod,
+    pub(crate) client_id: u16,
+    pub(crate) compression: CompressionMethod,
     pub(crate) arrow_options: ArrowOptions,
 }
 
@@ -60,8 +62,8 @@ impl ClientMetadata {
     /// Helper function to disable compression on the metadata.
     pub(crate) fn disable_compression(self) -> Self {
         Self {
-            client_id:     self.client_id,
-            compression:   CompressionMethod::None,
+            client_id: self.client_id,
+            compression: CompressionMethod::None,
             arrow_options: self.arrow_options,
         }
     }
@@ -82,25 +84,25 @@ impl ClientMetadata {
 /// A struct defining the information needed to connect over TCP.
 #[derive(Debug)]
 struct ConnectState<T: Send + Sync + 'static> {
-    status:  Arc<AtomicU8>,
+    status: Arc<AtomicU8>,
     channel: mpsc::Sender<Message<T>>,
     #[expect(unused)]
-    handle:  AbortHandle,
+    handle: AbortHandle,
 }
 
 // NOTE: ArcSwaps are used to support reconnects in the future.
 #[derive(Debug)]
 pub(super) struct Connection<T: ClientFormat> {
     #[expect(unused)]
-    addrs:         Arc<[SocketAddr]>,
-    options:       Arc<ClientOptions>,
-    io_task:       Arc<Mutex<IoHandle<T::Data>>>,
-    metadata:      ClientMetadata,
+    addrs: Arc<[SocketAddr]>,
+    options: Arc<ClientOptions>,
+    io_task: Arc<Mutex<IoHandle<T::Data>>>,
+    metadata: ClientMetadata,
     #[cfg(not(feature = "inner_pool"))]
-    state:         Arc<ConnectState<T::Data>>,
+    state: Arc<ConnectState<T::Data>>,
     /// NOTE: Max connections must remain at 4, unless algorithm changes
     #[cfg(feature = "inner_pool")]
-    state:         Vec<ArcSwap<ConnectState<T::Data>>>,
+    state: Vec<ArcSwap<ConnectState<T::Data>>>,
     #[cfg(feature = "inner_pool")]
     load_balancer: Arc<load::AtomicLoad>,
 }
@@ -414,8 +416,8 @@ impl<T: ClientFormat> Connection<T> {
 
         let client_hello = ClientHello {
             default_database: options.default_database.clone(),
-            username:         options.username.clone(),
-            password:         options.password.get().to_string(),
+            username: options.username.clone(),
+            password: options.password.get().to_string(),
         };
 
         // Send client hello
@@ -440,9 +442,13 @@ impl<T: ClientFormat> Connection<T> {
 }
 
 impl<T: ClientFormat> Connection<T> {
-    pub(crate) fn metadata(&self) -> ClientMetadata { self.metadata }
+    pub(crate) fn metadata(&self) -> ClientMetadata {
+        self.metadata
+    }
 
-    pub(crate) fn database(&self) -> &str { &self.options.default_database }
+    pub(crate) fn database(&self) -> &str {
+        &self.options.default_database
+    }
 
     #[cfg(feature = "inner_pool")]
     pub(crate) fn finish(&self, conn_idx: usize, weight: u8) {
@@ -497,7 +503,7 @@ mod load {
 
     #[derive(Debug)]
     pub(super) struct AtomicLoad {
-        load_counter:    AtomicUsize,
+        load_counter: AtomicUsize,
         max_connections: u8,
     }
 

--- a/clickhouse-arrow/src/client/internal.rs
+++ b/clickhouse-arrow/src/client/internal.rs
@@ -38,11 +38,11 @@ pub(crate) enum Operation<Data: Send + Sync> {
     Ping { response: oneshot::Sender<Result<()>> },
     #[strum(serialize = "Query")]
     Query {
-        query:    String,
+        query: String,
         settings: Option<Arc<Settings>>,
-        params:   Option<QueryParams>,
+        params: Option<QueryParams>,
         response: oneshot::Sender<Result<ResponseReceiver<Data>>>,
-        header:   Option<oneshot::Sender<Vec<(String, Type)>>>,
+        header: Option<oneshot::Sender<Vec<(String, Type)>>>,
     },
     #[strum(serialize = "Insert")]
     Insert { data: Data, response: oneshot::Sender<Result<()>> },
@@ -59,7 +59,9 @@ enum OperationTask {
 }
 
 impl Default for OperationTask {
-    fn default() -> Self { Self::Chunk(ChunkBoundary::default()) }
+    fn default() -> Self {
+        Self::Chunk(ChunkBoundary::default())
+    }
 }
 
 /// Track chunk boundaries. NOTE: Only relevant with chunked protocol for writing
@@ -87,30 +89,30 @@ pub(super) enum InsertState<T> {
 }
 
 pub(super) struct ExecutingQuery<T: Send + Sync> {
-    qid:             Qid,
-    state:           QueryState,
-    header:          Option<Vec<(String, Type)>>,
+    qid: Qid,
+    state: QueryState,
+    header: Option<Vec<(String, Type)>>,
     header_response: Option<oneshot::Sender<Vec<(String, Type)>>>,
-    response:        ResponseSender<T>,
+    response: ResponseSender<T>,
 }
 
 pub(super) struct PendingQuery<T: Send + Sync> {
-    qid:      Qid,
-    query:    String,
+    qid: Qid,
+    query: String,
     settings: Option<Arc<Settings>>,
-    params:   Option<QueryParams>,
+    params: Option<QueryParams>,
     response: oneshot::Sender<Result<ResponseReceiver<T>>>,
-    header:   Option<oneshot::Sender<Vec<(String, Type)>>>,
+    header: Option<oneshot::Sender<Vec<(String, Type)>>>,
 }
 
 pub(super) struct InternalConn<T: ClientFormat> {
-    cid:          &'static str,
+    cid: &'static str,
     server_hello: Arc<ServerHello>,
-    pending:      VecDeque<PendingQuery<T::Data>>,
-    executing:    Option<ExecutingQuery<T::Data>>,
-    events:       Arc<broadcast::Sender<Event>>,
-    metadata:     ClientMetadata,
-    state:        DeserializerState<T::Deser>,
+    pending: VecDeque<PendingQuery<T::Data>>,
+    executing: Option<ExecutingQuery<T::Data>>,
+    events: Arc<broadcast::Sender<Event>>,
+    metadata: ClientMetadata,
+    state: DeserializerState<T::Deser>,
 }
 
 impl<T: ClientFormat> InternalConn<T> {
@@ -525,11 +527,17 @@ impl<Data: Send + Sync + 'static> Operation<Data> {
     }
 
     // Helper functions to account for full weight across common operations
-    pub(crate) fn weight_query() -> u8 { 1 }
+    pub(crate) fn weight_query() -> u8 {
+        1
+    }
 
-    pub(crate) fn weight_insert() -> u8 { 5 }
+    pub(crate) fn weight_insert() -> u8 {
+        5
+    }
 
-    pub(crate) fn weight_insert_many() -> u8 { 6 }
+    pub(crate) fn weight_insert_many() -> u8 {
+        6
+    }
 }
 
 impl<Data: Send + Sync + 'static> std::fmt::Debug for Message<Data> {

--- a/clickhouse-arrow/src/client/options.rs
+++ b/clickhouse-arrow/src/client/options.rs
@@ -48,38 +48,38 @@ use crate::prelude::Secret;
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientOptions {
     /// Username credential
-    pub username:         String,
+    pub username: String,
     /// Password credential. [`Secret`] is used to minimize likelihood of exposure through logs
-    pub password:         Secret,
+    pub password: Secret,
     /// Scope this client to a specifc database, otherwise 'default' is used
     pub default_database: String,
     /// For tls, provide the domain, otherwise it will be determined from the endpoint.
-    pub domain:           Option<String>,
+    pub domain: Option<String>,
     /// Whether any non-ipv4 socket addrs should be filtered out.
-    pub ipv4_only:        bool,
+    pub ipv4_only: bool,
     /// Provide a path to a certificate authority to use for tls.
-    pub cafile:           Option<PathBuf>,
+    pub cafile: Option<PathBuf>,
     /// Whether a connection should be made securely over tls.
-    pub use_tls:          bool,
+    pub use_tls: bool,
     /// The compression to use when sending data to clickhouse.
-    pub compression:      CompressionMethod,
+    pub compression: CompressionMethod,
     /// Additional configuration not core to `ClickHouse` connections
     #[cfg_attr(feature = "serde", serde(default))]
-    pub ext:              Extension,
+    pub ext: Extension,
 }
 
 impl Default for ClientOptions {
     fn default() -> Self {
         ClientOptions {
-            username:         "default".to_string(),
-            password:         Secret::new(""),
+            username: "default".to_string(),
+            password: Secret::new(""),
             default_database: String::new(),
-            domain:           None,
-            ipv4_only:        false,
-            cafile:           None,
-            use_tls:          false,
-            compression:      CompressionMethod::default(),
-            ext:              Extension::default(),
+            domain: None,
+            ipv4_only: false,
+            cafile: None,
+            use_tls: false,
+            compression: CompressionMethod::default(),
+            ext: Extension::default(),
         }
     }
 }
@@ -87,7 +87,9 @@ impl Default for ClientOptions {
 impl ClientOptions {
     /// Create a new `ClientOptions` with default values.
     #[must_use]
-    pub fn new() -> Self { Self::default() }
+    pub fn new() -> Self {
+        Self::default()
+    }
 
     #[must_use]
     pub fn with_username(mut self, username: impl Into<String>) -> Self {
@@ -161,18 +163,18 @@ impl ClientOptions {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Extension {
     /// Options specific to (de)serializing arrow data.
-    pub arrow:          Option<ArrowOptions>,
+    pub arrow: Option<ArrowOptions>,
     /// Options specific to communicating with `ClickHouse` over their cloud offering.
     #[cfg(feature = "cloud")]
-    pub cloud:          CloudOptions,
+    pub cloud: CloudOptions,
     /// Options related to server/client protocol send chunking.
     /// This may be removed, as it may be defaulted.
     #[cfg_attr(feature = "serde", serde(default))]
-    pub chunked_send:   ChunkedProtocolMode,
+    pub chunked_send: ChunkedProtocolMode,
     /// Options related to server/client protocol recv chunking.
     /// This may be removed, as it may be defaulted
     #[cfg_attr(feature = "serde", serde(default))]
-    pub chunked_recv:   ChunkedProtocolMode,
+    pub chunked_recv: ChunkedProtocolMode,
     /// Related to `inner_pool`, how many 'inner clients' to spawn. Currently capped at 4.
     #[cfg(feature = "inner_pool")]
     #[cfg_attr(feature = "serde", serde(default))]
@@ -282,10 +284,10 @@ impl Extension {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ArrowOptions {
-    pub strings_as_strings:           bool,
-    pub use_date32_for_date:          bool,
-    pub strict_schema:                bool,
-    pub disable_strict_schema_ddl:    bool,
+    pub strings_as_strings: bool,
+    pub use_date32_for_date: bool,
+    pub strict_schema: bool,
+    pub disable_strict_schema_ddl: bool,
     pub nullable_array_default_empty: bool,
 }
 
@@ -314,7 +316,9 @@ impl Default for ArrowOptions {
     /// let arrow_options = ArrowOptions::default();
     /// println!("Nullable array default empty: {}", arrow_options.nullable_array_default_empty); // true
     /// ```
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ArrowOptions {
@@ -336,10 +340,10 @@ impl ArrowOptions {
     /// ```
     pub const fn new() -> Self {
         Self {
-            strings_as_strings:           false,
-            use_date32_for_date:          false,
-            strict_schema:                false,
-            disable_strict_schema_ddl:    false,
+            strings_as_strings: false,
+            use_date32_for_date: false,
+            strict_schema: false,
+            disable_strict_schema_ddl: false,
             nullable_array_default_empty: true,
         }
     }
@@ -365,10 +369,10 @@ impl ArrowOptions {
     /// ```
     pub const fn strict() -> Self {
         Self {
-            strings_as_strings:           false,
-            use_date32_for_date:          false,
-            strict_schema:                true,
-            disable_strict_schema_ddl:    false,
+            strings_as_strings: false,
+            use_date32_for_date: false,
+            strict_schema: true,
+            disable_strict_schema_ddl: false,
             nullable_array_default_empty: false,
         }
     }
@@ -715,5 +719,5 @@ pub struct CloudOptions {
     #[cfg_attr(feature = "serde", serde(default))]
     pub timeout: Option<u64>,
     #[cfg_attr(feature = "serde", serde(default))]
-    pub wakeup:  bool,
+    pub wakeup: bool,
 }

--- a/clickhouse-arrow/src/client/reader.rs
+++ b/clickhouse-arrow/src/client/reader.rs
@@ -452,7 +452,7 @@ impl<R: ClickHouseRead + 'static> Reader<R> {
 
     async fn read_table_columns(reader: &mut R) -> Result<TableColumns> {
         Ok(TableColumns {
-            name:        reader.read_utf8_string().await?,
+            name: reader.read_utf8_string().await?,
             description: reader.read_utf8_string().await?,
         })
     }

--- a/clickhouse-arrow/src/client/tcp.rs
+++ b/clickhouse-arrow/src/client/tcp.rs
@@ -145,7 +145,9 @@ impl From<Vec<SocketAddr>> for Destination {
 
 // From implementations for common destination types
 impl From<SocketAddr> for Destination {
-    fn from(addr: SocketAddr) -> Self { Destination { inner: DestinationInner::SocketAddr(addr) } }
+    fn from(addr: SocketAddr) -> Self {
+        Destination { inner: DestinationInner::SocketAddr(addr) }
+    }
 }
 
 impl From<(String, u16)> for Destination {
@@ -215,7 +217,9 @@ mod tests {
     use super::*;
 
     // Helper to create Destination variants
-    fn socket_addr() -> SocketAddr { SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000) }
+    fn socket_addr() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)
+    }
 
     #[tokio::test]
     async fn test_resolve_socket_addrs() {

--- a/clickhouse-arrow/src/client/writer.rs
+++ b/clickhouse-arrow/src/client/writer.rs
@@ -23,13 +23,13 @@ use crate::settings::Settings;
 
 #[derive(Debug)]
 pub(super) struct Query<'a> {
-    pub qid:      Qid,
-    pub info:     ClientInfo<'a>,
+    pub qid: Qid,
+    pub info: ClientInfo<'a>,
     pub settings: Option<Arc<Settings>>,
-    pub stage:    QueryProcessingStage,
+    pub stage: QueryProcessingStage,
     #[expect(clippy::struct_field_names)]
-    pub query:    &'a str,
-    pub params:   Option<QueryParams>,
+    pub query: &'a str,
+    pub params: Option<QueryParams>,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/clickhouse-arrow/src/compression.rs
+++ b/clickhouse-arrow/src/compression.rs
@@ -218,10 +218,10 @@ type BlockReadingFuture<'a, R> =
 /// let bytes_read = decompressor.read(&mut buffer).await.unwrap();
 /// ```
 pub(crate) struct DecompressionReader<'a, R: ClickHouseRead + 'static> {
-    mode:                 CompressionMethod,
-    inner:                Option<&'a mut R>,
-    decompressed:         Vec<u8>,
-    position:             usize,
+    mode: CompressionMethod,
+    inner: Option<&'a mut R>,
+    decompressed: Vec<u8>,
+    position: usize,
     block_reading_future: Option<BlockReadingFuture<'a, R>>,
 }
 

--- a/clickhouse-arrow/src/formats.rs
+++ b/clickhouse-arrow/src/formats.rs
@@ -62,7 +62,7 @@ pub(crate) mod sealed {
 /// Context maintained during deserialization
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct DeserializerState<T: Default = ()> {
-    pub(crate) options:      Option<ArrowOptions>,
+    pub(crate) options: Option<ArrowOptions>,
     pub(crate) deserializer: T,
 }
 
@@ -74,13 +74,15 @@ impl<T: Default> DeserializerState<T> {
     }
 
     #[must_use]
-    pub(crate) fn deserializer(&mut self) -> &mut T { &mut self.deserializer }
+    pub(crate) fn deserializer(&mut self) -> &mut T {
+        &mut self.deserializer
+    }
 }
 
 /// Context maintained during serialization
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SerializerState<T: Default = ()> {
-    pub(crate) options:    Option<ArrowOptions>,
+    pub(crate) options: Option<ArrowOptions>,
     pub(crate) serializer: T,
 }
 
@@ -93,5 +95,7 @@ impl<T: Default> SerializerState<T> {
 
     #[expect(unused)]
     #[must_use]
-    pub(crate) fn serializer(&mut self) -> &mut T { &mut self.serializer }
+    pub(crate) fn serializer(&mut self) -> &mut T {
+        &mut self.serializer
+    }
 }

--- a/clickhouse-arrow/src/formats/protocol_data.rs
+++ b/clickhouse-arrow/src/formats/protocol_data.rs
@@ -83,9 +83,13 @@ pub(crate) trait EmptyBlock {
 }
 
 impl EmptyBlock for crate::native::block::Block {
-    fn no_data(&self) -> bool { self.column_data.is_empty() && self.column_types.is_empty() }
+    fn no_data(&self) -> bool {
+        self.column_data.is_empty() && self.column_types.is_empty()
+    }
 }
 
 impl EmptyBlock for arrow::record_batch::RecordBatch {
-    fn no_data(&self) -> bool { self.num_rows() == 0 && self.num_columns() == 0 }
+    fn no_data(&self) -> bool {
+        self.num_rows() == 0 && self.num_columns() == 0
+    }
 }

--- a/clickhouse-arrow/src/native/block.rs
+++ b/clickhouse-arrow/src/native/block.rs
@@ -18,14 +18,14 @@ use crate::{Error, Result, Row, Type};
 /// A chunk of data in columnar form.
 pub struct Block {
     /// Metadata about the block
-    pub info:         BlockInfo,
+    pub info: BlockInfo,
     /// The number of rows contained in the block
-    pub rows:         u64,
+    pub rows: u64,
     /// The type of each column by name, in order.
     pub column_types: Vec<(String, Type)>,
     /// The data of each column by name, in order. All `Value` should correspond to the associated
     /// type in `column_types`.
-    pub column_data:  Vec<Value>,
+    pub column_data: Vec<Value>,
 }
 
 // Iterator type for `take_iter_rows`

--- a/clickhouse-arrow/src/native/block_info.rs
+++ b/clickhouse-arrow/src/native/block_info.rs
@@ -7,11 +7,13 @@ use crate::{Error, Result};
 #[derive(Debug, Clone, Copy)]
 pub struct BlockInfo {
     pub is_overflows: bool,
-    pub bucket_num:   i32,
+    pub bucket_num: i32,
 }
 
 impl Default for BlockInfo {
-    fn default() -> Self { BlockInfo { is_overflows: false, bucket_num: -1 } }
+    fn default() -> Self {
+        BlockInfo { is_overflows: false, bucket_num: -1 }
+    }
 }
 
 impl BlockInfo {

--- a/clickhouse-arrow/src/native/client_info.rs
+++ b/clickhouse-arrow/src/native/client_info.rs
@@ -25,35 +25,35 @@ pub(crate) enum QueryKind {
 
 #[derive(Debug)]
 pub(crate) struct OpenTelemetry<'a> {
-    trace_id:    Uuid,
-    span_id:     u64,
-    tracestate:  &'a str,
+    trace_id: Uuid,
+    span_id: u64,
+    tracestate: &'a str,
     trace_flags: u8,
 }
 
 #[derive(Debug)]
 pub(crate) struct ClientInfo<'a> {
-    pub kind:                        QueryKind,
-    pub initial_user:                &'a str,
-    pub initial_query_id:            &'a str,
-    pub initial_address:             &'a str,
+    pub kind: QueryKind,
+    pub initial_user: &'a str,
+    pub initial_query_id: &'a str,
+    pub initial_address: &'a str,
     // interface = TCP = 1
-    pub os_user:                     &'a str,
-    pub client_hostname:             &'a str,
-    pub client_name:                 &'a str,
-    pub client_version_major:        u64,
-    pub client_version_minor:        u64,
+    pub os_user: &'a str,
+    pub client_hostname: &'a str,
+    pub client_name: &'a str,
+    pub client_version_major: u64,
+    pub client_version_minor: u64,
     pub client_tcp_protocol_version: u64,
     // DBMS_MIN_PROTOCOL_VERSION_WITH_INITIAL_QUERY_START_TIME
-    pub query_start_time:            u64,
+    pub query_start_time: u64,
     // if DBMS_MIN_REVISION_WITH_QUOTA_KEY_IN_CLIENT_INFO
-    pub quota_key:                   &'a str,
+    pub quota_key: &'a str,
     // if DBMS_MIN_PROTOCOL_VERSION_WITH_DISTRIBUTED_DEPTH
-    pub distributed_depth:           u64,
+    pub distributed_depth: u64,
     // if DBMS_MIN_REVISION_WITH_VERSION_PATCH
-    pub client_version_patch:        u64,
+    pub client_version_patch: u64,
     // if DBMS_MIN_REVISION_WITH_OPENTELEMETRY
-    pub open_telemetry:              Option<OpenTelemetry<'a>>,
+    pub open_telemetry: Option<OpenTelemetry<'a>>,
 }
 
 impl Default for ClientInfo<'_> {

--- a/clickhouse-arrow/src/native/convert.rs
+++ b/clickhouse-arrow/src/native/convert.rs
@@ -18,7 +18,9 @@ pub trait ToSql {
 }
 
 impl ToSql for Value {
-    fn to_sql(self, _type_hint_: Option<&Type>) -> Result<Value> { Ok(self) }
+    fn to_sql(self, _type_hint_: Option<&Type>) -> Result<Value> {
+        Ok(self)
+    }
 }
 
 pub fn unexpected_type(type_: &Type) -> Error {
@@ -32,7 +34,9 @@ pub trait FromSql: Sized {
 }
 
 impl FromSql for Value {
-    fn from_sql(_type_: &Type, value: Value) -> Result<Self> { Ok(value) }
+    fn from_sql(_type_: &Type, value: Value) -> Result<Self> {
+        Ok(value)
+    }
 }
 
 /// A row that can be deserialized and serialized from a raw `ClickHouse` SQL value.

--- a/clickhouse-arrow/src/native/convert/raw_row.rs
+++ b/clickhouse-arrow/src/native/convert/raw_row.rs
@@ -10,9 +10,13 @@ pub struct RawRow(Vec<Option<(String, Type, Value)>>);
 impl Row for RawRow {
     const COLUMN_COUNT: Option<usize> = None;
 
-    fn column_names() -> Option<Vec<Cow<'static, str>>> { None }
+    fn column_names() -> Option<Vec<Cow<'static, str>>> {
+        None
+    }
 
-    fn to_schema() -> Option<Vec<(String, Type, Option<Value>)>> { None }
+    fn to_schema() -> Option<Vec<(String, Type, Option<Value>)>> {
+        None
+    }
 
     fn deserialize_row(map: Vec<(&str, &Type, Value)>) -> Result<Self> {
         Ok(Self(
@@ -60,10 +64,14 @@ impl<T: RowIndex + ?Sized> RowIndex for &T {
 
 impl RawRow {
     /// Determines if the row contains no values.
-    pub fn is_empty(&self) -> bool { self.0.is_empty() }
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 
     /// Returns the number of values in the row.
-    pub fn len(&self) -> usize { self.0.len() }
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
 
     /// # Panics
     ///

--- a/clickhouse-arrow/src/native/convert/std_serialize.rs
+++ b/clickhouse-arrow/src/native/convert/std_serialize.rs
@@ -6,55 +6,81 @@ use indexmap::IndexMap;
 use super::*;
 
 impl ToSql for u8 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::UInt8(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::UInt8(self))
+    }
 }
 
 impl ToSql for bool {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::UInt8(u8::from(self))) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::UInt8(u8::from(self)))
+    }
 }
 
 impl ToSql for u16 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::UInt16(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::UInt16(self))
+    }
 }
 
 impl ToSql for u32 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::UInt32(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::UInt32(self))
+    }
 }
 
 impl ToSql for u64 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::UInt64(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::UInt64(self))
+    }
 }
 
 impl ToSql for u128 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::UInt128(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::UInt128(self))
+    }
 }
 
 impl ToSql for i8 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Int8(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Int8(self))
+    }
 }
 
 impl ToSql for i16 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Int16(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Int16(self))
+    }
 }
 
 impl ToSql for i32 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Int32(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Int32(self))
+    }
 }
 
 impl ToSql for i64 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Int64(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Int64(self))
+    }
 }
 
 impl ToSql for i128 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Int128(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Int128(self))
+    }
 }
 
 impl ToSql for f32 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Float32(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Float32(self))
+    }
 }
 
 impl ToSql for f64 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Float64(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Float64(self))
+    }
 }
 
 impl ToSql for String {
@@ -150,15 +176,21 @@ impl<T: ToSql, const N: usize> ToSql for [T; N] {
 }
 
 impl<T: ToSql + Clone> ToSql for &T {
-    fn to_sql(self, type_hint: Option<&Type>) -> Result<Value> { self.clone().to_sql(type_hint) }
+    fn to_sql(self, type_hint: Option<&Type>) -> Result<Value> {
+        self.clone().to_sql(type_hint)
+    }
 }
 
 impl<T: ToSql + Clone> ToSql for &mut T {
-    fn to_sql(self, type_hint: Option<&Type>) -> Result<Value> { self.clone().to_sql(type_hint) }
+    fn to_sql(self, type_hint: Option<&Type>) -> Result<Value> {
+        self.clone().to_sql(type_hint)
+    }
 }
 
 impl<T: ToSql> ToSql for Box<T> {
-    fn to_sql(self, type_hint: Option<&Type>) -> Result<Value> { (*self).to_sql(type_hint) }
+    fn to_sql(self, type_hint: Option<&Type>) -> Result<Value> {
+        (*self).to_sql(type_hint)
+    }
 }
 
 macro_rules! tuple_impls {

--- a/clickhouse-arrow/src/native/convert/unit_value.rs
+++ b/clickhouse-arrow/src/native/convert/unit_value.rs
@@ -9,9 +9,13 @@ pub struct UnitValue<T: FromSql + ToSql>(pub T);
 impl<T: FromSql + ToSql> Row for UnitValue<T> {
     const COLUMN_COUNT: Option<usize> = Some(1);
 
-    fn column_names() -> Option<Vec<Cow<'static, str>>> { None }
+    fn column_names() -> Option<Vec<Cow<'static, str>>> {
+        None
+    }
 
-    fn to_schema() -> Option<Vec<(String, Type, Option<Value>)>> { None }
+    fn to_schema() -> Option<Vec<(String, Type, Option<Value>)>> {
+        None
+    }
 
     fn deserialize_row(map: Vec<(&str, &Type, Value)>) -> Result<Self> {
         if map.is_empty() {

--- a/clickhouse-arrow/src/native/error_codes.rs
+++ b/clickhouse-arrow/src/native/error_codes.rs
@@ -7,19 +7,23 @@ use crate::Error;
 /// Represents a server error mapped to internal severity
 #[derive(Debug, Clone)]
 pub struct ServerError {
-    pub error:       Severity,
-    pub code:        i32,
-    pub name:        String,
-    pub message:     String,
+    pub error: Severity,
+    pub code: i32,
+    pub name: String,
+    pub message: String,
     pub stack_trace: String,
 }
 
 impl ServerError {
-    pub(crate) fn is_fatal(&self) -> bool { matches!(self.error, Severity::Server(_)) }
+    pub(crate) fn is_fatal(&self) -> bool {
+        matches!(self.error, Severity::Server(_))
+    }
 }
 
 impl From<ServerError> for Error {
-    fn from(error: ServerError) -> Self { Error::ServerException(error) }
+    fn from(error: ServerError) -> Self {
+        Error::ServerException(error)
+    }
 }
 
 impl std::fmt::Display for ServerError {
@@ -41,10 +45,10 @@ impl std::fmt::Display for ServerError {
 /// Helper function to match server exception to server error
 pub(super) fn map_exception_to_error(exception: ServerException) -> ServerError {
     ServerError {
-        error:       map_error_code(exception.code),
-        code:        exception.code,
-        name:        exception.name,
-        message:     exception.message,
+        error: map_error_code(exception.code),
+        code: exception.code,
+        name: exception.name,
+        message: exception.message,
         stack_trace: exception.stack_trace,
     }
 }

--- a/clickhouse-arrow/src/native/progress.rs
+++ b/clickhouse-arrow/src/native/progress.rs
@@ -4,13 +4,13 @@
 /// See <https://clickhouse.com/codebrowser/ClickHouse/src/IO/Progress.h.html>
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct Progress {
-    pub read_rows:           u64,
-    pub read_bytes:          u64,
-    pub total_rows_to_read:  u64,
+    pub read_rows: u64,
+    pub read_bytes: u64,
+    pub total_rows_to_read: u64,
     pub total_bytes_to_read: Option<u64>,
-    pub written_rows:        Option<u64>,
-    pub written_bytes:       Option<u64>,
-    pub elapsed_ns:          Option<u64>,
+    pub written_rows: Option<u64>,
+    pub written_bytes: Option<u64>,
+    pub elapsed_ns: Option<u64>,
 }
 
 impl std::ops::Add for Progress {
@@ -24,13 +24,13 @@ impl std::ops::Add for Progress {
             (None, None) => None,
         };
         Self::Output {
-            read_rows:           self.read_rows + rhs.read_rows,
-            read_bytes:          self.read_bytes + rhs.read_bytes,
-            total_rows_to_read:  self.total_rows_to_read + rhs.total_rows_to_read,
+            read_rows: self.read_rows + rhs.read_rows,
+            read_bytes: self.read_bytes + rhs.read_bytes,
+            total_rows_to_read: self.total_rows_to_read + rhs.total_rows_to_read,
             total_bytes_to_read: sum_opt(self.total_bytes_to_read, rhs.total_bytes_to_read),
-            written_rows:        sum_opt(self.written_rows, rhs.written_rows),
-            written_bytes:       sum_opt(self.written_bytes, rhs.written_bytes),
-            elapsed_ns:          sum_opt(self.elapsed_ns, rhs.elapsed_ns),
+            written_rows: sum_opt(self.written_rows, rhs.written_rows),
+            written_bytes: sum_opt(self.written_bytes, rhs.written_bytes),
+            elapsed_ns: sum_opt(self.elapsed_ns, rhs.elapsed_ns),
         }
     }
 }
@@ -78,13 +78,13 @@ mod tests {
     #[test]
     fn test_progress_creation() {
         let progress = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       Some(512),
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: Some(512),
+            elapsed_ns: Some(1_000_000),
         };
 
         assert_eq!(progress.read_rows, 100);
@@ -99,13 +99,13 @@ mod tests {
     #[test]
     fn test_progress_clone_copy() {
         let progress = Progress {
-            read_rows:           123,
-            read_bytes:          456,
-            total_rows_to_read:  789,
+            read_rows: 123,
+            read_bytes: 456,
+            total_rows_to_read: 789,
             total_bytes_to_read: Some(1011),
-            written_rows:        Some(121),
-            written_bytes:       Some(314),
-            elapsed_ns:          Some(1516),
+            written_rows: Some(121),
+            written_bytes: Some(314),
+            elapsed_ns: Some(1516),
         };
 
         let cloned = progress;
@@ -118,13 +118,13 @@ mod tests {
     #[test]
     fn test_progress_debug() {
         let progress = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       Some(512),
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: Some(512),
+            elapsed_ns: Some(1_000_000),
         };
 
         let debug_str = format!("{progress:?}");
@@ -136,23 +136,23 @@ mod tests {
     #[test]
     fn test_progress_add_all_some() {
         let progress1 = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       Some(512),
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: Some(512),
+            elapsed_ns: Some(1_000_000),
         };
 
         let progress2 = Progress {
-            read_rows:           200,
-            read_bytes:          2048,
-            total_rows_to_read:  2000,
+            read_rows: 200,
+            read_bytes: 2048,
+            total_rows_to_read: 2000,
             total_bytes_to_read: Some(20480),
-            written_rows:        Some(100),
-            written_bytes:       Some(1024),
-            elapsed_ns:          Some(2_000_000),
+            written_rows: Some(100),
+            written_bytes: Some(1024),
+            elapsed_ns: Some(2_000_000),
         };
 
         let result = progress1 + progress2;
@@ -169,23 +169,23 @@ mod tests {
     #[test]
     fn test_progress_add_mixed_options() {
         let progress1 = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       None,
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: None,
+            elapsed_ns: Some(1_000_000),
         };
 
         let progress2 = Progress {
-            read_rows:           200,
-            read_bytes:          2048,
-            total_rows_to_read:  2000,
+            read_rows: 200,
+            read_bytes: 2048,
+            total_rows_to_read: 2000,
             total_bytes_to_read: None,
-            written_rows:        None,
-            written_bytes:       Some(1024),
-            elapsed_ns:          None,
+            written_rows: None,
+            written_bytes: Some(1024),
+            elapsed_ns: None,
         };
 
         let result = progress1 + progress2;
@@ -202,23 +202,23 @@ mod tests {
     #[test]
     fn test_progress_add_all_none() {
         let progress1 = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: None,
-            written_rows:        None,
-            written_bytes:       None,
-            elapsed_ns:          None,
+            written_rows: None,
+            written_bytes: None,
+            elapsed_ns: None,
         };
 
         let progress2 = Progress {
-            read_rows:           200,
-            read_bytes:          2048,
-            total_rows_to_read:  2000,
+            read_rows: 200,
+            read_bytes: 2048,
+            total_rows_to_read: 2000,
             total_bytes_to_read: None,
-            written_rows:        None,
-            written_bytes:       None,
-            elapsed_ns:          None,
+            written_rows: None,
+            written_bytes: None,
+            elapsed_ns: None,
         };
 
         let result = progress1 + progress2;
@@ -235,13 +235,13 @@ mod tests {
     #[test]
     fn test_progress_display() {
         let progress = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       Some(512),
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: Some(512),
+            elapsed_ns: Some(1_000_000),
         };
 
         let display_str = format!("{progress}");
@@ -263,13 +263,13 @@ mod tests {
     #[test]
     fn test_progress_display_with_nones() {
         let progress = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: None,
-            written_rows:        None,
-            written_bytes:       None,
-            elapsed_ns:          None,
+            written_rows: None,
+            written_bytes: None,
+            elapsed_ns: None,
         };
 
         let display_str = format!("{progress}");
@@ -283,33 +283,33 @@ mod tests {
     #[test]
     fn test_progress_equality() {
         let progress1 = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       Some(512),
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: Some(512),
+            elapsed_ns: Some(1_000_000),
         };
 
         let progress2 = Progress {
-            read_rows:           100,
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 100,
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       Some(512),
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: Some(512),
+            elapsed_ns: Some(1_000_000),
         };
 
         let progress3 = Progress {
-            read_rows:           200, // Different value
-            read_bytes:          1024,
-            total_rows_to_read:  1000,
+            read_rows: 200, // Different value
+            read_bytes: 1024,
+            total_rows_to_read: 1000,
             total_bytes_to_read: Some(10240),
-            written_rows:        Some(50),
-            written_bytes:       Some(512),
-            elapsed_ns:          Some(1_000_000),
+            written_rows: Some(50),
+            written_bytes: Some(512),
+            elapsed_ns: Some(1_000_000),
         };
 
         assert_eq!(progress1, progress2);

--- a/clickhouse-arrow/src/native/protocol.rs
+++ b/clickhouse-arrow/src/native/protocol.rs
@@ -85,29 +85,29 @@ pub(crate) enum QueryProcessingStage {
 #[repr(u64)]
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum ClientPacketId {
-    Hello                     = 0, // Name, version, revision, default DB
+    Hello = 0, // Name, version, revision, default DB
     // Query id, query settings, stage up to which the query must be executed, whether the
     // compression must be used, query text (without data for INSERTs).
-    Query                     = 1,
-    Data                      = 2, // A block of data (compressed or not).
-    Cancel                    = 3, // Cancel the query execution.
-    Ping                      = 4, // Check that connection to the server is alive.
-    TablesStatusRequest       = 5, // Check status of tables on the server.
-    KeepAlive                 = 6, // Keep the connection alive
-    Scalar                    = 7, // A block of data (compressed or not).
-    IgnoredPartUUIDs          = 8, // List of unique parts ids to exclude from query processing
-    ReadTaskResponse          = 9, // A filename to read from s3 (used in s3Cluster)
+    Query = 1,
+    Data = 2,                // A block of data (compressed or not).
+    Cancel = 3,              // Cancel the query execution.
+    Ping = 4,                // Check that connection to the server is alive.
+    TablesStatusRequest = 5, // Check status of tables on the server.
+    KeepAlive = 6,           // Keep the connection alive
+    Scalar = 7,              // A block of data (compressed or not).
+    IgnoredPartUUIDs = 8,    // List of unique parts ids to exclude from query processing
+    ReadTaskResponse = 9,    // A filename to read from s3 (used in s3Cluster)
     //Coordinator's decision with a modified set of mark ranges allowed to read
     MergeTreeReadTaskResponse = 10,
-    SSHChallengeRequest       = 11, // Request SSH signature challenge
-    SSHChallengeResponse      = 12, // Reply to SSH signature challenge
-    QueryPlan                 = 13, // Query plan
+    SSHChallengeRequest = 11,  // Request SSH signature challenge
+    SSHChallengeResponse = 12, // Reply to SSH signature challenge
+    QueryPlan = 13,            // Query plan
 }
 
 pub(crate) struct ClientHello {
     pub(crate) default_database: String,
-    pub(crate) username:         String,
-    pub(crate) password:         String,
+    pub(crate) username: String,
+    pub(crate) password: String,
 }
 
 /// `ServerPacketId` is the packet id read from `ClickHouse`.
@@ -116,25 +116,25 @@ pub(crate) struct ClientHello {
 #[repr(u64)]
 #[derive(Clone, Copy, Debug, AsRefStr)]
 pub(crate) enum ServerPacketId {
-    Hello                          = 0,
-    Data                           = 1,
-    Exception                      = 2,
-    Progress                       = 3,
-    Pong                           = 4,
-    EndOfStream                    = 5,
-    ProfileInfo                    = 6,
-    Totals                         = 7,
-    Extremes                       = 8,
-    TablesStatusResponse           = 9,
-    Log                            = 10,
-    TableColumns                   = 11,
-    PartUUIDs                      = 12,
-    ReadTaskRequest                = 13,
-    ProfileEvents                  = 14,
+    Hello = 0,
+    Data = 1,
+    Exception = 2,
+    Progress = 3,
+    Pong = 4,
+    EndOfStream = 5,
+    ProfileInfo = 6,
+    Totals = 7,
+    Extremes = 8,
+    TablesStatusResponse = 9,
+    Log = 10,
+    TableColumns = 11,
+    PartUUIDs = 12,
+    ReadTaskRequest = 13,
+    ProfileEvents = 14,
     MergeTreeAllRangesAnnouncement = 15,
-    MergeTreeReadTaskRequest       = 16, // Request from a MergeTree replica to a coordinator
-    TimezoneUpdate                 = 17, // Receive server's (session-wide) default timezone
-    SSHChallenge                   = 18, // Return challenge for SSH signature signing
+    MergeTreeReadTaskRequest = 16, // Request from a MergeTree replica to a coordinator
+    TimezoneUpdate = 17,           // Receive server's (session-wide) default timezone
+    SSHChallenge = 18,             // Return challenge for SSH signature signing
 }
 
 impl ServerPacketId {
@@ -198,17 +198,17 @@ pub(crate) enum ServerPacket<T = Block> {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct ServerHello {
     #[expect(unused)]
-    pub(crate) server_name:      String,
+    pub(crate) server_name: String,
     #[expect(unused)]
-    pub(crate) version:          (u64, u64, u64),
+    pub(crate) version: (u64, u64, u64),
     pub(crate) revision_version: u64,
     #[expect(unused)]
-    pub(crate) timezone:         Option<String>,
+    pub(crate) timezone: Option<String>,
     #[expect(unused)]
-    pub(crate) display_name:     Option<String>,
-    pub(crate) settings:         Option<Settings>,
-    pub(crate) chunked_send:     ChunkedProtocolMode,
-    pub(crate) chunked_recv:     ChunkedProtocolMode,
+    pub(crate) display_name: Option<String>,
+    pub(crate) settings: Option<Settings>,
+    pub(crate) chunked_send: ChunkedProtocolMode,
+    pub(crate) chunked_recv: ChunkedProtocolMode,
 }
 
 impl ServerHello {
@@ -234,42 +234,44 @@ pub(crate) struct ServerData<T> {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ServerException {
-    pub(crate) code:        i32,
-    pub(crate) name:        String,
-    pub(crate) message:     String,
+    pub(crate) code: i32,
+    pub(crate) name: String,
+    pub(crate) message: String,
     pub(crate) stack_trace: String,
     #[expect(unused)]
-    pub(crate) has_nested:  bool,
+    pub(crate) has_nested: bool,
 }
 
 impl ServerException {
-    pub(crate) fn emit(self) -> ServerError { map_exception_to_error(self) }
+    pub(crate) fn emit(self) -> ServerError {
+        map_exception_to_error(self)
+    }
 }
 
 #[expect(unused)]
 #[derive(Debug, Clone)]
 pub(crate) struct ProfileInfo {
-    pub(crate) rows:                         u64,
-    pub(crate) blocks:                       u64,
-    pub(crate) bytes:                        u64,
-    pub(crate) applied_limit:                bool,
-    pub(crate) rows_before_limit:            u64,
+    pub(crate) rows: u64,
+    pub(crate) blocks: u64,
+    pub(crate) bytes: u64,
+    pub(crate) applied_limit: bool,
+    pub(crate) rows_before_limit: u64,
     pub(crate) calculated_rows_before_limit: bool,
-    pub(crate) applied_aggregation:          bool,
-    pub(crate) rows_before_aggregation:      u64,
+    pub(crate) applied_aggregation: bool,
+    pub(crate) rows_before_aggregation: u64,
 }
 
 #[expect(unused)]
 #[derive(Debug, Clone)]
 pub(crate) struct TableColumns {
-    pub(crate) name:        String,
+    pub(crate) name: String,
     pub(crate) description: String,
 }
 
 #[expect(unused)]
 #[derive(Debug, Clone)]
 pub(crate) struct TableStatus {
-    pub(crate) is_replicated:  bool,
+    pub(crate) is_replicated: bool,
     pub(crate) absolute_delay: u32,
 }
 
@@ -280,14 +282,14 @@ pub(crate) struct TablesStatusResponse {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct LogData {
-    pub(crate) time:       String,
+    pub(crate) time: String,
     pub(crate) time_micro: u32,
-    pub(crate) host_name:  String,
-    pub(crate) query_id:   String,
-    pub(crate) thread_id:  u64,
-    pub(crate) priority:   i8,
-    pub(crate) source:     String,
-    pub(crate) text:       String,
+    pub(crate) host_name: String,
+    pub(crate) query_id: String,
+    pub(crate) thread_id: u64,
+    pub(crate) priority: i8,
+    pub(crate) source: String,
+    pub(crate) text: String,
 }
 
 impl LogData {
@@ -325,12 +327,12 @@ impl LogData {
 /// Emitted by `ClickHouse` during operations.
 #[derive(Debug, Clone, Default)]
 pub struct ProfileEvent {
-    pub(crate) host_name:    String,
+    pub(crate) host_name: String,
     pub(crate) current_time: String,
-    pub(crate) thread_id:    u64,
-    pub(crate) type_code:    i8,
-    pub(crate) name:         String,
-    pub(crate) value:        i64,
+    pub(crate) thread_id: u64,
+    pub(crate) type_code: i8,
+    pub(crate) name: String,
+    pub(crate) value: i64,
 }
 
 impl ProfileEvent {

--- a/clickhouse-arrow/src/native/types.rs
+++ b/clickhouse-arrow/src/native/types.rs
@@ -151,7 +151,9 @@ impl Type {
         }
     }
 
-    pub fn is_nullable(&self) -> bool { matches!(self, Type::Nullable(_)) }
+    pub fn is_nullable(&self) -> bool {
+        matches!(self, Type::Nullable(_))
+    }
 
     pub fn strip_low_cardinality(&self) -> &Type {
         match self {

--- a/clickhouse-arrow/src/native/types/deserialize.rs
+++ b/clickhouse-arrow/src/native/types/deserialize.rs
@@ -550,7 +550,9 @@ fn parse_fixed_args<const N: usize>(input: &str) -> Result<([&str; N], usize)> {
 }
 
 /// Parse arguments into a Vec for types with variable numbers of args
-fn parse_variable_args(input: &str) -> Result<Vec<&str>> { parse_args_iter(input)?.collect() }
+fn parse_variable_args(input: &str) -> Result<Vec<&str>> {
+    parse_args_iter(input)?.collect()
+}
 
 fn parse_scale(from: &str) -> Result<usize> {
     from.parse().map_err(|_| Error::TypeParseError("couldn't parse scale".to_string()))
@@ -574,11 +576,11 @@ fn parse_args_iter(input: &str) -> Result<impl Iterator<Item = Result<&str, Erro
 }
 
 struct ArgsIterator<'a> {
-    input:      &'a str,
+    input: &'a str,
     last_start: usize,
-    in_parens:  usize,
-    in_quotes:  bool,
-    done:       bool,
+    in_parens: usize,
+    in_quotes: bool,
+    done: bool,
 }
 
 impl<'a> Iterator for ArgsIterator<'a> {

--- a/clickhouse-arrow/src/native/types/deserialize/array.rs
+++ b/clickhouse-arrow/src/native/types/deserialize/array.rs
@@ -20,11 +20,17 @@ pub(crate) struct ArrayDeserializer;
 impl ArrayDeserializerGeneric for ArrayDeserializer {
     type Item = Value;
 
-    fn inner_type(type_: &Type) -> Result<&Type> { type_.unwrap_array() }
+    fn inner_type(type_: &Type) -> Result<&Type> {
+        type_.unwrap_array()
+    }
 
-    fn inner_value(items: Vec<Self::Item>) -> Value { Value::Array(items) }
+    fn inner_value(items: Vec<Self::Item>) -> Value {
+        Value::Array(items)
+    }
 
-    fn item_mapping(value: Value) -> Value { value }
+    fn item_mapping(value: Value) -> Value {
+        value
+    }
 }
 
 impl<T: ArrayDeserializerGeneric + 'static> Deserializer for T {

--- a/clickhouse-arrow/src/native/types/serialize/array.rs
+++ b/clickhouse-arrow/src/native/types/serialize/array.rs
@@ -14,11 +14,17 @@ pub(crate) trait ArraySerializerGeneric {
 
 pub(crate) struct ArraySerializer;
 impl ArraySerializerGeneric for ArraySerializer {
-    fn value_len(value: &Value) -> Result<usize> { value.unwrap_array_ref().map(<[Value]>::len) }
+    fn value_len(value: &Value) -> Result<usize> {
+        value.unwrap_array_ref().map(<[Value]>::len)
+    }
 
-    fn inner_type(type_: &Type) -> Result<&Type> { type_.unwrap_array() }
+    fn inner_type(type_: &Type) -> Result<&Type> {
+        type_.unwrap_array()
+    }
 
-    fn values(value: Value) -> Result<Vec<Value>> { value.unwrap_array() }
+    fn values(value: Value) -> Result<Vec<Value>> {
+        value.unwrap_array()
+    }
 }
 
 impl<T: ArraySerializerGeneric + 'static> Serializer for T {

--- a/clickhouse-arrow/src/native/types/tests.rs
+++ b/clickhouse-arrow/src/native/types/tests.rs
@@ -494,10 +494,10 @@ async fn roundtrip_map() {
     let values = &[
         Value::Map(vec![], vec![]),
         Value::Map(vec![Value::UInt32(1)], vec![Value::UInt16(2)]),
-        Value::Map(vec![Value::UInt32(5), Value::UInt32(3)], vec![
-            Value::UInt16(6),
-            Value::UInt16(4),
-        ]),
+        Value::Map(
+            vec![Value::UInt32(5), Value::UInt32(3)],
+            vec![Value::UInt16(6), Value::UInt16(4)],
+        ),
     ];
     assert_eq!(
         &values[..],
@@ -779,24 +779,21 @@ fn roundtrip_sized_int_types_sync() {
     let test_cases = vec![
         (Type::Int8, vec![Value::Int8(-128), Value::Int8(0), Value::Int8(127)]),
         (Type::Int16, vec![Value::Int16(-32768), Value::Int16(0), Value::Int16(32767)]),
-        (Type::Int32, vec![
-            Value::Int32(-2_147_483_648),
-            Value::Int32(0),
-            Value::Int32(2_147_483_647),
-        ]),
+        (
+            Type::Int32,
+            vec![Value::Int32(-2_147_483_648), Value::Int32(0), Value::Int32(2_147_483_647)],
+        ),
         (Type::Int64, vec![Value::Int64(i64::MIN), Value::Int64(0), Value::Int64(i64::MAX)]),
         (Type::UInt8, vec![Value::UInt8(0), Value::UInt8(128), Value::UInt8(255)]),
         (Type::UInt16, vec![Value::UInt16(0), Value::UInt16(32768), Value::UInt16(65535)]),
-        (Type::UInt32, vec![
-            Value::UInt32(0),
-            Value::UInt32(2_147_483_648),
-            Value::UInt32(u32::MAX),
-        ]),
-        (Type::UInt64, vec![
-            Value::UInt64(0),
-            Value::UInt64(u64::from(u32::MAX) + 1),
-            Value::UInt64(u64::MAX),
-        ]),
+        (
+            Type::UInt32,
+            vec![Value::UInt32(0), Value::UInt32(2_147_483_648), Value::UInt32(u32::MAX)],
+        ),
+        (
+            Type::UInt64,
+            vec![Value::UInt64(0), Value::UInt64(u64::from(u32::MAX) + 1), Value::UInt64(u64::MAX)],
+        ),
     ];
 
     for (type_, values) in test_cases {
@@ -825,22 +822,28 @@ fn roundtrip_sized_large_int_types_sync() {
 #[test]
 fn roundtrip_sized_float_types_sync() {
     let test_cases = vec![
-        (Type::Float32, vec![
-            Value::Float32(0.0),
-            Value::Float32(3.15),
-            Value::Float32(-1.0),
-            Value::Float32(f32::NAN),
-            Value::Float32(f32::INFINITY),
-            Value::Float32(f32::NEG_INFINITY),
-        ]),
-        (Type::Float64, vec![
-            Value::Float64(0.0),
-            Value::Float64(3.15),
-            Value::Float64(-1.0),
-            Value::Float64(f64::NAN),
-            Value::Float64(f64::INFINITY),
-            Value::Float64(f64::NEG_INFINITY),
-        ]),
+        (
+            Type::Float32,
+            vec![
+                Value::Float32(0.0),
+                Value::Float32(3.15),
+                Value::Float32(-1.0),
+                Value::Float32(f32::NAN),
+                Value::Float32(f32::INFINITY),
+                Value::Float32(f32::NEG_INFINITY),
+            ],
+        ),
+        (
+            Type::Float64,
+            vec![
+                Value::Float64(0.0),
+                Value::Float64(3.15),
+                Value::Float64(-1.0),
+                Value::Float64(f64::NAN),
+                Value::Float64(f64::INFINITY),
+                Value::Float64(f64::NEG_INFINITY),
+            ],
+        ),
     ];
 
     for (type_, values) in test_cases {
@@ -853,25 +856,30 @@ fn roundtrip_sized_float_types_sync() {
 #[test]
 fn roundtrip_sized_decimal_types_sync() {
     let test_cases = vec![
-        (Type::Decimal32(2), vec![
-            Value::Decimal32(2, -12345),
-            Value::Decimal32(2, 0),
-            Value::Decimal32(2, 12345),
-        ]),
-        (Type::Decimal64(4), vec![
-            Value::Decimal64(4, -123_456_789),
-            Value::Decimal64(4, 0),
-            Value::Decimal64(4, 123_456_789),
-        ]),
-        (Type::Decimal128(6), vec![
-            Value::Decimal128(6, -123_456_789_012_345),
-            Value::Decimal128(6, 0),
-            Value::Decimal128(6, 123_456_789_012_345),
-        ]),
-        (Type::Decimal256(8), vec![
-            Value::Decimal256(8, i256([0u8; 32])),
-            Value::Decimal256(8, i256([1u8; 32])),
-        ]),
+        (
+            Type::Decimal32(2),
+            vec![Value::Decimal32(2, -12345), Value::Decimal32(2, 0), Value::Decimal32(2, 12345)],
+        ),
+        (
+            Type::Decimal64(4),
+            vec![
+                Value::Decimal64(4, -123_456_789),
+                Value::Decimal64(4, 0),
+                Value::Decimal64(4, 123_456_789),
+            ],
+        ),
+        (
+            Type::Decimal128(6),
+            vec![
+                Value::Decimal128(6, -123_456_789_012_345),
+                Value::Decimal128(6, 0),
+                Value::Decimal128(6, 123_456_789_012_345),
+            ],
+        ),
+        (
+            Type::Decimal256(8),
+            vec![Value::Decimal256(8, i256([0u8; 32])), Value::Decimal256(8, i256([1u8; 32]))],
+        ),
     ];
 
     for (type_, values) in test_cases {
@@ -888,14 +896,17 @@ fn roundtrip_sized_date_time_types_sync() {
         (Type::Date, vec![Value::Date(Date(0)), Value::Date(Date(18262))]), /* 1970-01-01 to
                                                                              * 2020-01-01 */
         (Type::Date32, vec![Value::Date32(Date32(0)), Value::Date32(Date32(-719_163))]), /* 1900-01-01 */
-        (Type::DateTime(UTC), vec![
-            Value::DateTime(DateTime(UTC, 0)),
-            Value::DateTime(DateTime(UTC, 1_577_836_800)),
-        ]), /* 1970-01-01 to 2020-01-01 */
-        (Type::DateTime64(3, UTC), vec![
-            Value::DateTime64(DynDateTime64(UTC, 0, 3)),
-            Value::DateTime64(DynDateTime64(UTC, 1_577_836_800_000, 3)),
-        ]),
+        (
+            Type::DateTime(UTC),
+            vec![Value::DateTime(DateTime(UTC, 0)), Value::DateTime(DateTime(UTC, 1_577_836_800))],
+        ), /* 1970-01-01 to 2020-01-01 */
+        (
+            Type::DateTime64(3, UTC),
+            vec![
+                Value::DateTime64(DynDateTime64(UTC, 0, 3)),
+                Value::DateTime64(DynDateTime64(UTC, 1_577_836_800_000, 3)),
+            ],
+        ),
     ];
 
     for (type_, values) in test_cases {
@@ -909,15 +920,21 @@ fn roundtrip_sized_date_time_types_sync() {
 fn roundtrip_sized_network_types_sync() {
     use crate::{Ipv4, Ipv6};
     let test_cases = vec![
-        (Type::Ipv4, vec![
-            Value::Ipv4(Ipv4(Ipv4Addr::UNSPECIFIED)),
-            Value::Ipv4(Ipv4(Ipv4Addr::new(192, 168, 1, 1))),
-            Value::Ipv4(Ipv4(Ipv4Addr::BROADCAST)),
-        ]),
-        (Type::Ipv6, vec![
-            Value::Ipv6(Ipv6(Ipv6Addr::UNSPECIFIED)),
-            Value::Ipv6(Ipv6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
-        ]),
+        (
+            Type::Ipv4,
+            vec![
+                Value::Ipv4(Ipv4(Ipv4Addr::UNSPECIFIED)),
+                Value::Ipv4(Ipv4(Ipv4Addr::new(192, 168, 1, 1))),
+                Value::Ipv4(Ipv4(Ipv4Addr::BROADCAST)),
+            ],
+        ),
+        (
+            Type::Ipv6,
+            vec![
+                Value::Ipv6(Ipv6(Ipv6Addr::UNSPECIFIED)),
+                Value::Ipv6(Ipv6(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1))),
+            ],
+        ),
     ];
 
     for (type_, values) in test_cases {
@@ -949,16 +966,22 @@ fn roundtrip_sized_enum_types_sync() {
     ];
 
     let test_cases = vec![
-        (Type::Enum8(enum8_values.clone()), vec![
-            Value::Enum8("red".to_string(), 1),
-            Value::Enum8("green".to_string(), 2),
-            Value::Enum8("blue".to_string(), 3),
-        ]),
-        (Type::Enum16(enum16_values.clone()), vec![
-            Value::Enum16("small".to_string(), 100),
-            Value::Enum16("medium".to_string(), 200),
-            Value::Enum16("large".to_string(), 300),
-        ]),
+        (
+            Type::Enum8(enum8_values.clone()),
+            vec![
+                Value::Enum8("red".to_string(), 1),
+                Value::Enum8("green".to_string(), 2),
+                Value::Enum8("blue".to_string(), 3),
+            ],
+        ),
+        (
+            Type::Enum16(enum16_values.clone()),
+            vec![
+                Value::Enum16("small".to_string(), 100),
+                Value::Enum16("medium".to_string(), 200),
+                Value::Enum16("large".to_string(), 300),
+            ],
+        ),
     ];
 
     for (type_, values) in test_cases {

--- a/clickhouse-arrow/src/native/values.rs
+++ b/clickhouse-arrow/src/native/values.rs
@@ -201,7 +201,9 @@ impl Hash for Value {
 impl Eq for Value {}
 
 impl Value {
-    pub fn string(value: impl Into<String>) -> Self { Value::String(value.into().into_bytes()) }
+    pub fn string(value: impl Into<String>) -> Self {
+        Value::String(value.into().into_bytes())
+    }
 
     /// # Errors
     /// Returns an error if the value is an unsigned integer.
@@ -262,13 +264,17 @@ impl Value {
     ///
     /// # Errors
     /// Returns an error if the conversion fails.
-    pub fn to_value<T: FromSql>(self, type_: &Type) -> Result<T> { T::from_sql(type_, self) }
+    pub fn to_value<T: FromSql>(self, type_: &Type) -> Result<T> {
+        T::from_sql(type_, self)
+    }
 
     /// Converts a [`Value`] to a `T` type by calling [`ToSql::to_sql`] on `T`.
     ///
     /// # Errors
     /// Returns an error if the conversion fails.
-    pub fn from_value<T: ToSql>(value: T) -> Result<Self> { value.to_sql(None) }
+    pub fn from_value<T: ToSql>(value: T) -> Result<Self> {
+        value.to_sql(None)
+    }
 
     /// Guesses a [`Type`] from the value, may not correspond to actual column type in `ClickHouse`
     pub fn guess_type(&self) -> Type {

--- a/clickhouse-arrow/src/native/values/bytes.rs
+++ b/clickhouse-arrow/src/native/values/bytes.rs
@@ -59,17 +59,25 @@ impl FromSql for Bytes {
 impl Deref for Bytes {
     type Target = Vec<u8>;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl DerefMut for Bytes {
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl From<Bytes> for Vec<u8> {
-    fn from(value: Bytes) -> Self { value.0 }
+    fn from(value: Bytes) -> Self {
+        value.0
+    }
 }
 
 impl From<Vec<u8>> for Bytes {
-    fn from(value: Vec<u8>) -> Self { Self(value) }
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
 }

--- a/clickhouse-arrow/src/native/values/clickhouse_uuid.rs
+++ b/clickhouse-arrow/src/native/values/clickhouse_uuid.rs
@@ -1,7 +1,9 @@
 use crate::{FromSql, Result, ToSql, Type, Uuid, Value, unexpected_type};
 
 impl ToSql for Uuid {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Uuid(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Uuid(self))
+    }
 }
 
 impl FromSql for Uuid {

--- a/clickhouse-arrow/src/native/values/date.rs
+++ b/clickhouse-arrow/src/native/values/date.rs
@@ -53,7 +53,9 @@ impl<'de> serde::Deserialize<'de> for Date {
 }
 
 impl ToSql for Date {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Date(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Date(self))
+    }
 }
 
 impl FromSql for Date {
@@ -90,7 +92,9 @@ pub struct Date32(pub i32);
 #[expect(clippy::cast_possible_truncation)]
 impl Date32 {
     /// Creates a `Date32` from days since 1900-01-01.
-    pub fn from_days(days: i32) -> Self { Date32(days) }
+    pub fn from_days(days: i32) -> Self {
+        Date32(days)
+    }
 
     /// Creates a `Date32` from milliseconds since 1970-01-01, adjusting to 1900-01-01 epoch.
     pub fn from_millis(ms: i64) -> Self {
@@ -122,7 +126,9 @@ impl<'de> serde::Deserialize<'de> for Date32 {
 }
 
 impl ToSql for Date32 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Date32(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Date32(self))
+    }
 }
 
 impl FromSql for Date32 {
@@ -258,7 +264,9 @@ impl<'de> serde::Deserialize<'de> for DateTime {
 }
 
 impl ToSql for DateTime {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::DateTime(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::DateTime(self))
+    }
 }
 
 impl FromSql for DateTime {
@@ -274,7 +282,9 @@ impl FromSql for DateTime {
 }
 
 impl Default for DateTime {
-    fn default() -> Self { Self(UTC, 0) }
+    fn default() -> Self {
+        Self(UTC, 0)
+    }
 }
 
 impl TryFrom<DateTime> for chrono::DateTime<Tz> {
@@ -382,7 +392,9 @@ impl DynDateTime64 {
 }
 
 impl<const PRECISION: usize> From<DateTime64<PRECISION>> for DynDateTime64 {
-    fn from(value: DateTime64<PRECISION>) -> Self { Self(value.0, value.1, PRECISION) }
+    fn from(value: DateTime64<PRECISION>) -> Self {
+        Self(value.0, value.1, PRECISION)
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -463,7 +475,9 @@ impl<const PRECISION: usize> FromSql for DateTime64<PRECISION> {
 }
 
 impl<const PRECISION: usize> Default for DateTime64<PRECISION> {
-    fn default() -> Self { Self(UTC, 0) }
+    fn default() -> Self {
+        Self(UTC, 0)
+    }
 }
 
 impl ToSql for chrono::DateTime<Utc> {
@@ -853,15 +867,21 @@ mod chrono_tests {
 
     #[test]
     #[should_panic(expected = "DateTime out of range for u32: -1")]
-    fn test_datetime_panic_secs() { let _d = DateTime::from_seconds(-1, None); }
+    fn test_datetime_panic_secs() {
+        let _d = DateTime::from_seconds(-1, None);
+    }
 
     #[test]
     #[should_panic(expected = "DateTime out of range for u32: -1")]
-    fn test_datetime_panic_millis() { let _d = DateTime::from_millis(-1_000, None); }
+    fn test_datetime_panic_millis() {
+        let _d = DateTime::from_millis(-1_000, None);
+    }
 
     #[test]
     #[should_panic(expected = "DateTime out of range for u32: -1")]
-    fn test_datetime_panic_micros() { let _d = DateTime::from_micros(-1_000_000, None); }
+    fn test_datetime_panic_micros() {
+        let _d = DateTime::from_micros(-1_000_000, None);
+    }
 
     #[test]
     fn test_datetime64() {

--- a/clickhouse-arrow/src/native/values/decimal.rs
+++ b/clickhouse-arrow/src/native/values/decimal.rs
@@ -2,7 +2,9 @@ use rust_decimal::Decimal;
 
 use crate::{Error, FromSql, Result, ToSql, Type, Value, unexpected_type};
 
-fn count_digits_i128(n: i128) -> u32 { if n == 0 { 1 } else { n.abs().ilog10() + 1 } }
+fn count_digits_i128(n: i128) -> u32 {
+    if n == 0 { 1 } else { n.abs().ilog10() + 1 }
+}
 
 impl FromSql for Decimal {
     #[expect(clippy::cast_possible_truncation)]

--- a/clickhouse-arrow/src/native/values/fixed_point.rs
+++ b/clickhouse-arrow/src/native/values/fixed_point.rs
@@ -10,11 +10,17 @@ use crate::{FromSql, Result, ToSql, Type, Value, i256, unexpected_type};
 pub struct FixedPoint32<const SCALE: u64>(pub i32);
 
 impl<const SCALE: u64> FixedPoint32<SCALE> {
-    pub const fn modulus(&self) -> i32 { 10i32.pow(SCALE as u32) }
+    pub const fn modulus(&self) -> i32 {
+        10i32.pow(SCALE as u32)
+    }
 
-    pub fn integer(&self) -> i32 { self.0 / 10i32.pow(SCALE as u32) }
+    pub fn integer(&self) -> i32 {
+        self.0 / 10i32.pow(SCALE as u32)
+    }
 
-    pub fn fraction(&self) -> i32 { self.0 % 10i32.pow(SCALE as u32) }
+    pub fn fraction(&self) -> i32 {
+        self.0 % 10i32.pow(SCALE as u32)
+    }
 }
 
 impl<const SCALE: u64> ToSql for FixedPoint32<SCALE> {
@@ -65,11 +71,17 @@ impl<const SCALE: u64> FromSql for FixedPoint64<SCALE> {
 }
 
 impl<const SCALE: u64> FixedPoint64<SCALE> {
-    pub const fn modulus(&self) -> i64 { 10i64.pow(SCALE as u32) }
+    pub const fn modulus(&self) -> i64 {
+        10i64.pow(SCALE as u32)
+    }
 
-    pub fn integer(&self) -> i64 { self.0 / 10i64.pow(SCALE as u32) }
+    pub fn integer(&self) -> i64 {
+        self.0 / 10i64.pow(SCALE as u32)
+    }
 
-    pub fn fraction(&self) -> i64 { self.0 % 10i64.pow(SCALE as u32) }
+    pub fn fraction(&self) -> i64 {
+        self.0 % 10i64.pow(SCALE as u32)
+    }
 }
 
 impl<const SCALE: u64> From<FixedPoint64<SCALE>> for f64 {
@@ -102,11 +114,17 @@ impl<const SCALE: u64> FromSql for FixedPoint128<SCALE> {
 }
 
 impl<const SCALE: u64> FixedPoint128<SCALE> {
-    pub const fn modulus(&self) -> i128 { 10i128.pow(SCALE as u32) }
+    pub const fn modulus(&self) -> i128 {
+        10i128.pow(SCALE as u32)
+    }
 
-    pub fn integer(&self) -> i128 { self.0 / 10i128.pow(SCALE as u32) }
+    pub fn integer(&self) -> i128 {
+        self.0 / 10i128.pow(SCALE as u32)
+    }
 
-    pub fn fraction(&self) -> i128 { self.0 % 10i128.pow(SCALE as u32) }
+    pub fn fraction(&self) -> i128 {
+        self.0 % 10i128.pow(SCALE as u32)
+    }
 }
 
 impl<const SCALE: u64> From<FixedPoint128<SCALE>> for f64 {
@@ -144,7 +162,9 @@ impl<const SCALE: u64> FixedPoint256<SCALE> {
 
     /// Create a fixed-point number from a raw scaled integer value
     /// The value is assumed to already have the correct scaling applied
-    pub fn from_raw(value: i128) -> Self { FixedPoint256(i256::from(value)) }
+    pub fn from_raw(value: i128) -> Self {
+        FixedPoint256(i256::from(value))
+    }
 
     /// Create a fixed-point number from a value and decimal exponent
     /// e.g., (123, -2) represents 123 × 10^-2 = 1.23
@@ -256,10 +276,14 @@ impl<const SCALE: u64> From<i128> for FixedPoint256<SCALE> {
 }
 
 impl<const SCALE: u64> From<(i128, i32)> for FixedPoint256<SCALE> {
-    fn from(parts: (i128, i32)) -> Self { Self::from_parts(parts.0, parts.1) }
+    fn from(parts: (i128, i32)) -> Self {
+        Self::from_parts(parts.0, parts.1)
+    }
 }
 
 #[cfg(feature = "rust_decimal")]
 impl<const SCALE: u64> From<rust_decimal::Decimal> for FixedPoint256<SCALE> {
-    fn from(decimal: rust_decimal::Decimal) -> Self { Self::from_decimal(decimal) }
+    fn from(decimal: rust_decimal::Decimal) -> Self {
+        Self::from_decimal(decimal)
+    }
 }

--- a/clickhouse-arrow/src/native/values/geo.rs
+++ b/clickhouse-arrow/src/native/values/geo.rs
@@ -19,10 +19,14 @@ impl Hash for Point {
 impl std::ops::Index<u8> for Point {
     type Output = f64;
 
-    fn index(&self, index: u8) -> &Self::Output { &self.0[index as usize] }
+    fn index(&self, index: u8) -> &Self::Output {
+        &self.0[index as usize]
+    }
 }
 impl AsRef<[f64; 2]> for Point {
-    fn as_ref(&self) -> &[f64; 2] { &self.0 }
+    fn as_ref(&self) -> &[f64; 2] {
+        &self.0
+    }
 }
 
 /// Polygon without holes.
@@ -50,7 +54,9 @@ pub struct MultiPolygon(pub Vec<Polygon>);
 macro_rules! to_from_sql {
     ($name:ident) => {
         impl ToSql for $name {
-            fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::$name(self)) }
+            fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+                Ok(Value::$name(self))
+            }
         }
 
         impl FromSql for $name {
@@ -97,19 +103,27 @@ mod nav_types_conversions {
     }
     // Points and coords
     impl From<Point> for geo_types::Coord {
-        fn from(source: Point) -> Self { Self { x: source[0], y: source[1] } }
+        fn from(source: Point) -> Self {
+            Self { x: source[0], y: source[1] }
+        }
     }
     impl From<geo_types::Coord> for Point {
-        fn from(source: geo_types::Coord) -> Self { Self([source.x, source.y]) }
+        fn from(source: geo_types::Coord) -> Self {
+            Self([source.x, source.y])
+        }
     }
     to_from_sql!(geo_types::Coord, Point);
 
     // Points and points
     impl From<Point> for geo_types::Point {
-        fn from(source: Point) -> Self { geo_types::Point(source.into()) }
+        fn from(source: Point) -> Self {
+            geo_types::Point(source.into())
+        }
     }
     impl From<geo_types::Point> for Point {
-        fn from(source: geo_types::Point) -> Self { source.0.into() }
+        fn from(source: geo_types::Point) -> Self {
+            source.0.into()
+        }
     }
     to_from_sql!(geo_types::Point, Point);
     // Rings and Linestrings
@@ -127,7 +141,9 @@ mod nav_types_conversions {
     // Rings and polygons (with no holes)
     // A Polygon -> Ring conversion is not provided, as the polygon might have holes.
     impl From<Ring> for geo_types::Polygon {
-        fn from(source: Ring) -> Self { geo_types::Polygon::new(source.0.into(), vec![]) }
+        fn from(source: Ring) -> Self {
+            geo_types::Polygon::new(source.0.into(), vec![])
+        }
     }
     // Polygons and polygons
     impl From<geo_types::Polygon> for Polygon {

--- a/clickhouse-arrow/src/native/values/int256.rs
+++ b/clickhouse-arrow/src/native/values/int256.rs
@@ -10,11 +10,15 @@ use crate::{FromSql, Result, ToSql, Type, Value, unexpected_type};
 pub struct i256(pub [u8; 32]);
 
 impl From<i256> for u256 {
-    fn from(i: i256) -> Self { u256(i.0) }
+    fn from(i: i256) -> Self {
+        u256(i.0)
+    }
 }
 
 impl ToSql for i256 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Int256(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Int256(self))
+    }
 }
 
 impl FromSql for i256 {
@@ -165,7 +169,9 @@ impl std::ops::Mul<i256> for i256 {
 pub struct u256(pub [u8; 32]);
 
 impl ToSql for u256 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::UInt256(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::UInt256(self))
+    }
 }
 
 impl FromSql for u256 {
@@ -181,7 +187,9 @@ impl FromSql for u256 {
 }
 
 impl From<u256> for i256 {
-    fn from(u: u256) -> Self { i256(u.0) }
+    fn from(u: u256) -> Self {
+        i256(u.0)
+    }
 }
 
 impl From<u256> for (u128, u128) {

--- a/clickhouse-arrow/src/native/values/ip.rs
+++ b/clickhouse-arrow/src/native/values/ip.rs
@@ -10,25 +10,35 @@ use super::*;
 pub struct Ipv4(pub Ipv4Addr);
 
 impl fmt::Display for Ipv4 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl Deref for Ipv4 {
     type Target = Ipv4Addr;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<Ipv4> for Ipv4Addr {
-    fn from(i: Ipv4) -> Self { i.0 }
+    fn from(i: Ipv4) -> Self {
+        i.0
+    }
 }
 
 impl From<Ipv4Addr> for Ipv4 {
-    fn from(x: Ipv4Addr) -> Self { Self(x) }
+    fn from(x: Ipv4Addr) -> Self {
+        Self(x)
+    }
 }
 
 impl Default for Ipv4 {
-    fn default() -> Self { Self(Ipv4Addr::UNSPECIFIED) }
+    fn default() -> Self {
+        Self(Ipv4Addr::UNSPECIFIED)
+    }
 }
 
 /// Wrapper type for `ClickHouse` `IPv6` type.
@@ -37,29 +47,41 @@ impl Default for Ipv4 {
 pub struct Ipv6(pub Ipv6Addr);
 
 impl fmt::Display for Ipv6 {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { self.0.fmt(f) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl Deref for Ipv6 {
     type Target = Ipv6Addr;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl From<Ipv6> for Ipv6Addr {
-    fn from(i: Ipv6) -> Self { i.0 }
+    fn from(i: Ipv6) -> Self {
+        i.0
+    }
 }
 
 impl From<Ipv6Addr> for Ipv6 {
-    fn from(x: Ipv6Addr) -> Self { Self(x) }
+    fn from(x: Ipv6Addr) -> Self {
+        Self(x)
+    }
 }
 
 impl Default for Ipv6 {
-    fn default() -> Self { Self(Ipv6Addr::UNSPECIFIED) }
+    fn default() -> Self {
+        Self(Ipv6Addr::UNSPECIFIED)
+    }
 }
 
 impl ToSql for Ipv4 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Ipv4(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Ipv4(self))
+    }
 }
 
 impl FromSql for Ipv4 {
@@ -75,7 +97,9 @@ impl FromSql for Ipv4 {
 }
 
 impl ToSql for Ipv6 {
-    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> { Ok(Value::Ipv6(self)) }
+    fn to_sql(self, _type_hint: Option<&Type>) -> Result<Value> {
+        Ok(Value::Ipv6(self))
+    }
 }
 
 impl FromSql for Ipv6 {

--- a/clickhouse-arrow/src/native/values/tests.rs
+++ b/clickhouse-arrow/src/native/values/tests.rs
@@ -666,11 +666,10 @@ fn test_value_display_formatting() {
     assert_eq!(Value::Null.to_string(), "NULL");
 
     // Test Map display
-    let map =
-        Value::Map(vec![Value::String(b"key1".to_vec()), Value::String(b"key2".to_vec())], vec![
-            Value::Int32(1),
-            Value::Int32(2),
-        ]);
+    let map = Value::Map(
+        vec![Value::String(b"key1".to_vec()), Value::String(b"key2".to_vec())],
+        vec![Value::Int32(1), Value::Int32(2)],
+    );
     assert_eq!(map.to_string(), "{'key1':1,'key2':2}");
     assert_eq!(Value::Map(vec![], vec![]).to_string(), "{}");
 

--- a/clickhouse-arrow/src/pool.rs
+++ b/clickhouse-arrow/src/pool.rs
@@ -28,8 +28,8 @@ pub type ConnectionPool<T> = bb8::Pool<ConnectionManager<T>>;
 /// Helper to construct a bb8 connection pool
 pub struct ConnectionPoolBuilder<T: ClientFormat> {
     client_builder: ClientBuilder,
-    pool:           PoolBuilder<T>,
-    check_health:   bool,
+    pool: PoolBuilder<T>,
+    check_health: bool,
 }
 
 impl<T: ClientFormat> ConnectionPoolBuilder<T> {
@@ -46,13 +46,19 @@ impl<T: ClientFormat> ConnectionPoolBuilder<T> {
     }
 
     /// Get the underlying client builder's unique identifier.
-    pub fn connection_identifier(&self) -> String { self.client_builder.connection_identifier() }
+    pub fn connection_identifier(&self) -> String {
+        self.client_builder.connection_identifier()
+    }
 
     /// Get a reference to the current configured [`ClientOptions`]
-    pub fn client_options(&self) -> &ClientOptions { self.client_builder.options() }
+    pub fn client_options(&self) -> &ClientOptions {
+        self.client_builder.options()
+    }
 
     /// Get a reference to the current configured [`Settings`]
-    pub fn client_settings(&self) -> Option<&Settings> { self.client_builder.settings() }
+    pub fn client_settings(&self) -> Option<&Settings> {
+        self.client_builder.settings()
+    }
 
     /// Whether the underlying connection will issue a `ping` when checking health.
     #[must_use]
@@ -107,9 +113,9 @@ impl<T: ClientFormat> ConnectionPoolBuilder<T> {
 /// `ConnectionManager` is the underlying manager that `bb8::Pool` uses to manage connections.
 #[derive(Clone)]
 pub struct ConnectionManager<T: ClientFormat> {
-    builder:      ClientBuilder,
+    builder: ClientBuilder,
     check_health: bool,
-    _phantom:     std::marker::PhantomData<Client<T>>,
+    _phantom: std::marker::PhantomData<Client<T>>,
 }
 
 impl<T: ClientFormat> ConnectionManager<T> {
@@ -190,9 +196,13 @@ impl<T: ClientFormat> ConnectionManager<T> {
     }
 
     /// Useful to determine if 2 connections are essentially the same
-    pub fn connection_identifier(&self) -> String { self.builder.connection_identifier() }
+    pub fn connection_identifier(&self) -> String {
+        self.builder.connection_identifier()
+    }
 
-    async fn connect(&self) -> Result<Client<T>> { self.builder.clone().build().await }
+    async fn connect(&self) -> Result<Client<T>> {
+        self.builder.clone().build().await
+    }
 }
 
 impl<T: ClientFormat> ManageConnection for ConnectionManager<T> {
@@ -243,20 +253,20 @@ impl<T: ClientFormat> ManageConnection for ConnectionManager<T> {
 #[derive(Debug, Clone, Copy)]
 pub struct ExponentialBackoff {
     current_interval: Duration,
-    factor:           f64,
-    max_interval:     Duration,
+    factor: f64,
+    max_interval: Duration,
     max_elapsed_time: Option<Duration>,
-    attempts:         u32,
+    attempts: u32,
 }
 
 impl ExponentialBackoff {
     pub fn new() -> Self {
         ExponentialBackoff {
             current_interval: Duration::from_millis(10), // Start with 100ms
-            factor:           2.0,
-            max_interval:     Duration::from_secs(60),
+            factor: 2.0,
+            max_interval: Duration::from_secs(60),
             max_elapsed_time: Some(Duration::from_secs(900)), // 15 minutes
-            attempts:         0,
+            attempts: 0,
         }
     }
 
@@ -278,5 +288,7 @@ impl ExponentialBackoff {
 }
 
 impl Default for ExponentialBackoff {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }

--- a/clickhouse-arrow/src/prelude.rs
+++ b/clickhouse-arrow/src/prelude.rs
@@ -32,10 +32,14 @@ pub use crate::{ArrowClient, Client, ClientBuilder, CompressionMethod, NativeCli
 pub struct Secret(String);
 
 impl Secret {
-    pub fn new<P: AsRef<str>>(s: P) -> Self { Self(s.as_ref().to_string()) }
+    pub fn new<P: AsRef<str>>(s: P) -> Self {
+        Self(s.as_ref().to_string())
+    }
 
     #[must_use]
-    pub fn get(&self) -> &str { &self.0 }
+    pub fn get(&self) -> &str {
+        &self.0
+    }
 }
 
 impl std::fmt::Debug for Secret {
@@ -45,7 +49,9 @@ impl std::fmt::Debug for Secret {
 }
 
 impl<T: AsRef<str>> From<T> for Secret {
-    fn from(s: T) -> Self { Self(s.as_ref().to_string()) }
+    fn from(s: T) -> Self {
+        Self(s.as_ref().to_string())
+    }
 }
 
 /// Custom Deserialize implementation to prevent storing passwords

--- a/clickhouse-arrow/src/query.rs
+++ b/clickhouse-arrow/src/query.rs
@@ -12,15 +12,21 @@ use crate::{Result, Settings};
 pub struct Qid(Uuid);
 
 impl Default for Qid {
-    fn default() -> Self { Self::new() }
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Qid {
     /// Generate a new `v4` [`Uuid`]
-    pub fn new() -> Self { Self(Uuid::new_v4()) }
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
 
     /// Take the inner [`Uuid`]
-    pub fn into_inner(self) -> Uuid { self.0 }
+    pub fn into_inner(self) -> Uuid {
+        self.0
+    }
 
     // Convert to 32-char hex string, no heap allocation
     pub(crate) async fn write_id<W: ClickHouseWrite>(&self, writer: &mut W) -> Result<()> {
@@ -46,7 +52,9 @@ impl<T: Into<Qid>> From<Option<T>> for Qid {
 }
 
 impl From<Uuid> for Qid {
-    fn from(id: Uuid) -> Self { Self(id) }
+    fn from(id: Uuid) -> Self {
+        Self(id)
+    }
 }
 
 impl fmt::Display for Qid {
@@ -95,7 +103,9 @@ where
 
 impl From<QueryParams> for Settings {
     /// Helpful to serialize params when dispatching a query
-    fn from(value: QueryParams) -> Settings { value.0.into_iter().collect() }
+    fn from(value: QueryParams) -> Settings {
+        value.0.into_iter().collect()
+    }
 }
 
 /// Represents a parsed query.
@@ -109,21 +119,31 @@ pub struct ParsedQuery(pub(crate) String);
 impl std::ops::Deref for ParsedQuery {
     type Target = String;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl fmt::Display for ParsedQuery {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
 }
 
 impl From<String> for ParsedQuery {
-    fn from(q: String) -> ParsedQuery { ParsedQuery(q.trim().to_string()) }
+    fn from(q: String) -> ParsedQuery {
+        ParsedQuery(q.trim().to_string())
+    }
 }
 
 impl From<&str> for ParsedQuery {
-    fn from(q: &str) -> ParsedQuery { ParsedQuery(q.trim().to_string()) }
+    fn from(q: &str) -> ParsedQuery {
+        ParsedQuery(q.trim().to_string())
+    }
 }
 
 impl From<&String> for ParsedQuery {
-    fn from(q: &String) -> ParsedQuery { ParsedQuery(q.trim().to_string()) }
+    fn from(q: &String) -> ParsedQuery {
+        ParsedQuery(q.trim().to_string())
+    }
 }

--- a/clickhouse-arrow/src/schema.rs
+++ b/clickhouse-arrow/src/schema.rs
@@ -87,15 +87,15 @@ impl std::fmt::Display for ClickHouseEngine {
 #[derive(Debug, Default, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CreateOptions {
-    pub engine:                String,
-    pub order_by:              Vec<String>,
-    pub primary_keys:          Vec<String>,
-    pub partition_by:          Option<String>,
-    pub sampling:              Option<String>,
-    pub settings:              Settings,
-    pub ttl:                   Option<String>,
-    pub schema_conversions:    Option<SchemaConversions>,
-    pub defaults:              Option<HashMap<String, String>>,
+    pub engine: String,
+    pub order_by: Vec<String>,
+    pub primary_keys: Vec<String>,
+    pub partition_by: Option<String>,
+    pub sampling: Option<String>,
+    pub settings: Settings,
+    pub ttl: Option<String>,
+    pub schema_conversions: Option<SchemaConversions>,
+    pub defaults: Option<HashMap<String, String>>,
     pub defaults_for_nullable: bool,
 }
 
@@ -284,7 +284,9 @@ impl CreateOptions {
     ///
     /// # Returns
     /// An optional reference to the `HashMap` of column names to default values.
-    pub fn defaults(&self) -> Option<&HashMap<String, String>> { self.defaults.as_ref() }
+    pub fn defaults(&self) -> Option<&HashMap<String, String>> {
+        self.defaults.as_ref()
+    }
 
     /// Returns the configured default values, if any.
     ///
@@ -621,7 +623,9 @@ pub trait ColumnDefine: Sized {
 impl<T: Row> ColumnDefine for T {
     type DefaultValue = crate::Value;
 
-    fn definitions() -> Option<Vec<ColumnDefinition>> { Self::to_schema() }
+    fn definitions() -> Option<Vec<ColumnDefinition>> {
+        Self::to_schema()
+    }
 
     fn runtime_definitions(
         &self,
@@ -650,14 +654,16 @@ impl<T: Row> ColumnDefine for T {
 /// Helper struct to encapsulate schema creation logic for Arrow schemas.
 pub(crate) struct RecordBatchDefinition {
     pub(crate) arrow_options: Option<ArrowOptions>,
-    pub(crate) schema:        SchemaRef,
-    pub(crate) defaults:      Option<HashMap<String, String>>,
+    pub(crate) schema: SchemaRef,
+    pub(crate) defaults: Option<HashMap<String, String>>,
 }
 
 impl ColumnDefine for RecordBatchDefinition {
     type DefaultValue = String;
 
-    fn definitions() -> Option<Vec<ColumnDefinition<String>>> { None }
+    fn definitions() -> Option<Vec<ColumnDefinition<String>>> {
+        None
+    }
 
     fn runtime_definitions(
         &self,
@@ -757,9 +763,10 @@ mod tests {
     #[test]
     fn test_create_options_with_setting() {
         let options = CreateOptions::new("MergeTree").with_setting("index_granularity", 4096);
-        assert_eq!(options.settings.encode_to_strings(), vec![
-            "index_granularity = 4096".to_string()
-        ]);
+        assert_eq!(
+            options.settings.encode_to_strings(),
+            vec!["index_granularity = 4096".to_string()]
+        );
     }
 
     #[test]

--- a/clickhouse-arrow/src/settings.rs
+++ b/clickhouse-arrow/src/settings.rs
@@ -101,19 +101,25 @@ impl Eq for SettingValue {}
 macro_rules! setting_value {
     ($ty:ident, $inner:ty) => {
         impl From<$inner> for SettingValue {
-            fn from(value: $inner) -> Self { SettingValue::$ty(value) }
+            fn from(value: $inner) -> Self {
+                SettingValue::$ty(value)
+            }
         }
     };
     ($ty:ident, $inner:ty, $override:ty) => {
         impl From<$override> for SettingValue {
             #[allow(clippy::cast_lossless)]
             #[allow(clippy::cast_possible_wrap)]
-            fn from(value: $override) -> Self { SettingValue::$ty(value as $inner) }
+            fn from(value: $override) -> Self {
+                SettingValue::$ty(value as $inner)
+            }
         }
     };
     ($ty:ident, $inner:ty, $v:tt =>  { $override:expr }) => {
         impl From<$inner> for SettingValue {
-            fn from($v: $inner) -> Self { SettingValue::$ty($override) }
+            fn from($v: $inner) -> Self {
+                SettingValue::$ty($override)
+            }
         }
     };
 }
@@ -165,10 +171,10 @@ impl fmt::Display for SettingValue {
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Setting {
-    key:       String,
-    value:     SettingValue,
+    key: String,
+    value: SettingValue,
     important: bool,
-    custom:    bool,
+    custom: bool,
 }
 
 impl Setting {
@@ -311,12 +317,7 @@ impl Setting {
 
 impl<T: Into<String>, U: Into<SettingValue>> From<(T, U)> for Setting {
     fn from(value: (T, U)) -> Self {
-        Setting {
-            key:       value.0.into(),
-            value:     value.1.into(),
-            important: false,
-            custom:    false,
-        }
+        Setting { key: value.0.into(), value: value.1.into(), important: false, custom: false }
     }
 }
 
@@ -502,7 +503,9 @@ impl Settings {
     }
 
     /// Internal helper to find a specific settings
-    pub(crate) fn get(&self, key: &str) -> Option<&Setting> { self.0.iter().find(|s| s.key == key) }
+    pub(crate) fn get(&self, key: &str) -> Option<&Setting> {
+        self.0.iter().find(|s| s.key == key)
+    }
 }
 
 impl<T, K, S> From<T> for Settings
@@ -516,10 +519,10 @@ where
             value
                 .into_iter()
                 .map(|(k, v)| Setting {
-                    key:       k.into(),
-                    value:     v.into(),
+                    key: k.into(),
+                    value: v.into(),
                     important: false,
-                    custom:    false,
+                    custom: false,
                 })
                 .collect(),
         )
@@ -542,7 +545,9 @@ where
 impl std::ops::Deref for Settings {
     type Target = [Setting];
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -962,10 +967,13 @@ mod tests {
         ]);
 
         let kv_pairs = settings.encode_to_key_value_strings();
-        assert_eq!(kv_pairs, vec![
-            ("max_threads".to_string(), "8".to_string()),
-            ("default_format".to_string(), "JSON".to_string()),
-        ]);
+        assert_eq!(
+            kv_pairs,
+            vec![
+                ("max_threads".to_string(), "8".to_string()),
+                ("default_format".to_string(), "JSON".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/clickhouse-arrow/src/spawn.rs
+++ b/clickhouse-arrow/src/spawn.rs
@@ -48,7 +48,9 @@ impl<R: 'static> SpawnedTask<R> {
     ///
     /// # Errors
     /// Returns an error if the underlying task cannot be polled.
-    pub async fn join(self) -> Result<R, JoinError> { self.await }
+    pub async fn join(self) -> Result<R, JoinError> {
+        self.await
+    }
 
     /// Joins the task and unwinds the panic if it happens.
     ///
@@ -81,7 +83,9 @@ impl<R> Future for SpawnedTask<R> {
 }
 
 impl<R> Drop for SpawnedTask<R> {
-    fn drop(&mut self) { self.inner.abort(); }
+    fn drop(&mut self) {
+        self.inner.abort();
+    }
 }
 
 #[cfg(test)]

--- a/clickhouse-arrow/src/telemetry.rs
+++ b/clickhouse-arrow/src/telemetry.rs
@@ -45,9 +45,13 @@ impl TraceContext {
 }
 
 impl From<NonZeroU64> for TraceContext {
-    fn from(id: NonZeroU64) -> Self { Self(Some(id)) }
+    fn from(id: NonZeroU64) -> Self {
+        Self(Some(id))
+    }
 }
 
 impl From<Option<NonZeroU64>> for TraceContext {
-    fn from(id: Option<NonZeroU64>) -> Self { Self(id) }
+    fn from(id: Option<NonZeroU64>) -> Self {
+        Self(id)
+    }
 }

--- a/clickhouse-arrow/src/test_utils.rs
+++ b/clickhouse-arrow/src/test_utils.rs
@@ -116,13 +116,13 @@ pub async fn create_container(conf: Option<&str>) -> Arc<ClickHouseContainer> {
 }
 
 pub struct ClickHouseContainer {
-    pub endpoint:    String,
+    pub endpoint: String,
     pub native_port: u16,
-    pub http_port:   u16,
-    pub url:         String,
-    pub user:        String,
-    pub password:    String,
-    container:       RwLock<Option<ContainerAsync<GenericImage>>>,
+    pub http_port: u16,
+    pub url: String,
+    pub user: String,
+    pub password: String,
+    container: RwLock<Option<ContainerAsync<GenericImage>>>,
 }
 
 impl ClickHouseContainer {
@@ -177,13 +177,21 @@ impl ClickHouseContainer {
         Ok(ClickHouseContainer { endpoint, native_port, http_port, url, user, password, container })
     }
 
-    pub fn get_native_url(&self) -> &str { &self.url }
+    pub fn get_native_url(&self) -> &str {
+        &self.url
+    }
 
-    pub fn get_native_port(&self) -> u16 { self.native_port }
+    pub fn get_native_port(&self) -> u16 {
+        self.native_port
+    }
 
-    pub fn get_http_url(&self) -> String { format!("http://{}:{}", self.endpoint, self.http_port) }
+    pub fn get_http_url(&self) -> String {
+        format!("http://{}:{}", self.endpoint, self.http_port)
+    }
 
-    pub fn get_http_port(&self) -> u16 { self.http_port }
+    pub fn get_http_port(&self) -> u16 {
+        self.http_port
+    }
 
     /// # Errors
     pub async fn shutdown(&self) -> Result<(), TestcontainersError> {
@@ -298,17 +306,20 @@ pub mod arrow_tests {
             Arc::new(BinaryArray::from_iter_values((0..rows).map(|i| format!("name{i}"))))
                 as ArrayRef
         };
-        RecordBatch::try_new(schema, vec![
-            id_row,
-            name_row,
-            Arc::new(Float64Array::from((0..rows).map(|i| i as f64).collect::<Vec<_>>())),
-            Arc::new(
-                TimestampMillisecondArray::from(
-                    (0..rows).map(|i| i as i64 * 1000).collect::<Vec<_>>(),
-                )
-                .with_timezone(Arc::from("UTC")),
-            ),
-        ])
+        RecordBatch::try_new(
+            schema,
+            vec![
+                id_row,
+                name_row,
+                Arc::new(Float64Array::from((0..rows).map(|i| i as f64).collect::<Vec<_>>())),
+                Arc::new(
+                    TimestampMillisecondArray::from(
+                        (0..rows).map(|i| i as i64 * 1000).collect::<Vec<_>>(),
+                    )
+                    .with_timezone(Arc::from("UTC")),
+                ),
+            ],
+        )
         .unwrap()
     }
 }

--- a/clickhouse-arrow/tests/common/arrow_helpers.rs
+++ b/clickhouse-arrow/tests/common/arrow_helpers.rs
@@ -841,65 +841,68 @@ pub fn test_record_batch() -> RecordBatch {
         .unwrap(),
     );
 
-    RecordBatch::try_new(test_schema(), vec![
-        // Primitives
-        id as ArrayRef,
-        int8_col,
-        int16_col,
-        int32_col,
-        int64_col,
-        uint8_col,
-        uint16_col,
-        uint32_col,
-        uint64_col,
-        int128_col,
-        uint128_col, // 10
-        int256_col,
-        uint256_col,
-        float32_col,
-        float64_col,
-        // String
-        string_col,
-        fixed_string_col,
-        // Decimal
-        decimal32_col,
-        decimal64_col,
-        // Datetimes
-        date_col,
-        date32_col, // 20
-        datetime_col,
-        datetime_utc_col,
-        datetime_est_col,
-        datetime64_3_ny_col,
-        datetime64_6_tokyo_col,
-        datetime64_9_utc_col,
-        // Map and Tuple
-        map_array,
-        tuple_int32_string_col,
-        // Special
-        ipv4_col,
-        ipv6_col, // 30
-        uuid_col,
-        //
-        // TODO
-        // json_col,
-        // point_col,
-        //
-        // Enums
-        enum8_col,
-        enum8_int32_col,
-        enum16_col,
-        // LowCardinality
-        low_cardinality_string_col,
-        low_cardinality_nullable_string_col,
-        // Arrays
-        array_low_cardinality_string_col,
-        array_int32_col,
-        array_nullable_int32_col,
-        array_nullable_string_col, // 40
-        large_list_int32_col,
-        array_tuple_col,
-    ])
+    RecordBatch::try_new(
+        test_schema(),
+        vec![
+            // Primitives
+            id as ArrayRef,
+            int8_col,
+            int16_col,
+            int32_col,
+            int64_col,
+            uint8_col,
+            uint16_col,
+            uint32_col,
+            uint64_col,
+            int128_col,
+            uint128_col, // 10
+            int256_col,
+            uint256_col,
+            float32_col,
+            float64_col,
+            // String
+            string_col,
+            fixed_string_col,
+            // Decimal
+            decimal32_col,
+            decimal64_col,
+            // Datetimes
+            date_col,
+            date32_col, // 20
+            datetime_col,
+            datetime_utc_col,
+            datetime_est_col,
+            datetime64_3_ny_col,
+            datetime64_6_tokyo_col,
+            datetime64_9_utc_col,
+            // Map and Tuple
+            map_array,
+            tuple_int32_string_col,
+            // Special
+            ipv4_col,
+            ipv6_col, // 30
+            uuid_col,
+            //
+            // TODO
+            // json_col,
+            // point_col,
+            //
+            // Enums
+            enum8_col,
+            enum8_int32_col,
+            enum16_col,
+            // LowCardinality
+            low_cardinality_string_col,
+            low_cardinality_nullable_string_col,
+            // Arrays
+            array_low_cardinality_string_col,
+            array_int32_col,
+            array_nullable_int32_col,
+            array_nullable_string_col, // 40
+            large_list_int32_col,
+            array_tuple_col,
+        ],
+    )
     .expect("Failed to create RecordBatch")
 }
 
@@ -946,9 +949,10 @@ pub fn low_cardinality_nullable_record_batch() -> RecordBatch {
         .unwrap(),
     );
 
-    RecordBatch::try_new(low_cardinality_nullable_schema(), vec![
-        low_cardinality_nullable_string_col,
-    ])
+    RecordBatch::try_new(
+        low_cardinality_nullable_schema(),
+        vec![low_cardinality_nullable_string_col],
+    )
     .expect("Failed to create RecordBatch")
 }
 
@@ -967,31 +971,34 @@ pub fn low_cardinality_array_schema() -> Arc<Schema> {
 
 /// # Panics
 pub fn low_cardinality_array_record_batch() -> RecordBatch {
-    RecordBatch::try_new(low_cardinality_array_schema(), vec![Arc::new(
-        ListArray::try_new(
-            Arc::new(Field::new(
-                "item",
-                DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
-                true,
-            )),
-            OffsetBuffer::new(vec![0, 2, 2, 3, 4, 6].into()),
-            Arc::new(
-                DictionaryArray::<Int32Type>::try_new(
-                    Int32Array::from(vec![
-                        Some(0),
-                        Some(1), // Row 1: ["low", "card"]
-                        Some(2), // Row 3: ["test"]
-                        None,    // Row 4: [null]
-                        Some(0),
-                        None, // Row 5: ["low", null]
-                    ]),
-                    Arc::new(StringArray::from(vec!["low", "card", "test"])),
-                )
-                .unwrap(),
-            ),
-            None,
-        )
-        .unwrap(),
-    )])
+    RecordBatch::try_new(
+        low_cardinality_array_schema(),
+        vec![Arc::new(
+            ListArray::try_new(
+                Arc::new(Field::new(
+                    "item",
+                    DataType::Dictionary(Box::new(DataType::Int32), Box::new(DataType::Utf8)),
+                    true,
+                )),
+                OffsetBuffer::new(vec![0, 2, 2, 3, 4, 6].into()),
+                Arc::new(
+                    DictionaryArray::<Int32Type>::try_new(
+                        Int32Array::from(vec![
+                            Some(0),
+                            Some(1), // Row 1: ["low", "card"]
+                            Some(2), // Row 3: ["test"]
+                            None,    // Row 4: [null]
+                            Some(0),
+                            None, // Row 5: ["low", null]
+                        ]),
+                        Arc::new(StringArray::from(vec!["low", "card", "test"])),
+                    )
+                    .unwrap(),
+                ),
+                None,
+            )
+            .unwrap(),
+        )],
+    )
     .expect("Failed to create RecordBatch")
 }

--- a/clickhouse-arrow/tests/common/native_helpers.rs
+++ b/clickhouse-arrow/tests/common/native_helpers.rs
@@ -9,43 +9,43 @@ use uuid::Uuid;
 #[cfg_attr(feature = "derive", derive(Row))]
 #[cfg_attr(feature = "derive", clickhouse_arrow(schema = get_testrowall_schema))]
 pub struct TestRowAll {
-    id:                        u64,
-    int8_col:                  i8,
-    int16_col:                 i16,
-    int32_col:                 i32,
-    int64_col:                 i64,
-    uint8_col:                 u8,
-    uint16_col:                u16,
-    uint32_col:                u32,
-    uint64_col:                u64,
-    uint128_col:               u128,
-    uint256_col:               u256,
-    date_col:                  Date,
-    datetime_col:              DateTime,
-    datetime64_col:            DateTime64<3>,
+    id: u64,
+    int8_col: i8,
+    int16_col: i16,
+    int32_col: i32,
+    int64_col: i64,
+    uint8_col: u8,
+    uint16_col: u16,
+    uint32_col: u32,
+    uint64_col: u64,
+    uint128_col: u128,
+    uint256_col: u256,
+    date_col: Date,
+    datetime_col: DateTime,
+    datetime64_col: DateTime64<3>,
     #[cfg(feature = "rust_decimal")]
-    decimal32_col:             rust_decimal::Decimal,
+    decimal32_col: rust_decimal::Decimal,
     #[cfg(not(feature = "rust_decimal"))]
-    decimal32_col:             FixedPoint32<4>,
+    decimal32_col: FixedPoint32<4>,
     #[cfg(feature = "rust_decimal")]
-    decimal64_col:             rust_decimal::Decimal,
+    decimal64_col: rust_decimal::Decimal,
     #[cfg(not(feature = "rust_decimal"))]
-    decimal64_col:             FixedPoint64<6>,
+    decimal64_col: FixedPoint64<6>,
     #[cfg(feature = "rust_decimal")]
-    decimal128_col:            rust_decimal::Decimal,
+    decimal128_col: rust_decimal::Decimal,
     #[cfg(not(feature = "rust_decimal"))]
-    decimal128_col:            FixedPoint128<8>,
-    decimal256_col:            FixedPoint256<10>,
-    nullable_string_col:       Option<String>,
-    nullable_int32_col:        Option<i32>,
-    nullable_uint64_col:       Option<u64>,
-    array_uint64_col:          Vec<u64>,
-    array_string_col:          Vec<String>,
-    array_nullable_int32_col:  Vec<Option<i32>>,
+    decimal128_col: FixedPoint128<8>,
+    decimal256_col: FixedPoint256<10>,
+    nullable_string_col: Option<String>,
+    nullable_int32_col: Option<i32>,
+    nullable_uint64_col: Option<u64>,
+    array_uint64_col: Vec<u64>,
+    array_string_col: Vec<String>,
+    array_nullable_int32_col: Vec<Option<i32>>,
     array_nullable_string_col: Vec<Option<String>>,
-    string_col:                String,
-    fixed_string_col:          String, // FixedString(5) trimmed to String
-    uuid_col:                  Uuid,
+    string_col: String,
+    fixed_string_col: String, // FixedString(5) trimmed to String
+    uuid_col: Uuid,
 }
 
 pub fn get_testrowall_schema() -> Vec<ColumnDefinition> {

--- a/clickhouse-arrow/tests/tests/arrow.rs
+++ b/clickhouse-arrow/tests/tests/arrow.rs
@@ -488,10 +488,10 @@ pub async fn test_nullable_array_serialization(ch: Arc<ClickHouseContainer>) {
 
     let nullable_array = builder.finish();
 
-    let batch = RecordBatch::try_new(Arc::clone(&schema), vec![
-        Arc::new(id_array),
-        Arc::new(nullable_array),
-    ])
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![Arc::new(id_array), Arc::new(nullable_array)],
+    )
     .expect("Failed to create RecordBatch");
 
     // Create unique table name

--- a/clickhouse-arrow/tests/tests/compat.rs
+++ b/clickhouse-arrow/tests/tests/compat.rs
@@ -40,10 +40,13 @@ pub async fn test_arrow_compat(ch: Arc<ClickHouseContainer>) {
         Field::new("id", DataType::Int32, false),
         Field::new("name", DataType::Utf8, false),
     ]));
-    let batch = RecordBatch::try_new(Arc::clone(&schema), vec![
-        Arc::new(Int32Array::from(ids.clone())) as ArrayRef,
-        Arc::new(StringArray::from(names.clone())) as ArrayRef,
-    ])
+    let batch = RecordBatch::try_new(
+        Arc::clone(&schema),
+        vec![
+            Arc::new(Int32Array::from(ids.clone())) as ArrayRef,
+            Arc::new(StringArray::from(names.clone())) as ArrayRef,
+        ],
+    )
     .unwrap();
 
     // Create schema


### PR DESCRIPTION
## Summary
Upgrades the Arrow dependency from v55 to v56 to enable compatibility with modern Rust Arrow ecosystem crates (Polars 0.44+, DataFusion 44+, etc.).

## Changes
- Updated arrow dependency from v55 to v56 in Cargo.toml
- Added support for new Decimal32 and Decimal64 types in arrow/types.rs
- Zero-copy Arrow integration preserved
- No performance regressions expected

## Breaking Changes in Arrow v56
- Decimal32 and Decimal64 types added (handled)
- Dictionary ID handling changes (not used by clickhouse-arrow)
- IPC API deprecations (not used by clickhouse-arrow)

## Testing
- ✅ All 985 tests passing
- ✅ cargo fmt completed
- ✅ cargo clippy no warnings

This upgrade enables clickhouse-arrow to integrate with the modern Arrow v56+ ecosystem without dependency conflicts.