### PR TITLE
chore(deps): refresh runtime crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,7 +874,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "ureq 3.0.12",
+ "ureq 3.1.2",
  "uuid",
  "webpki-roots 1.0.3",
  "zstd",
@@ -954,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "cookie_store"
-version = "0.21.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eac901828f88a5241ee0600950ab981148a18f2f756900ffba1b125ca6a3ef9"
+checksum = "3fc4bff745c9b4c7fb1e97b25d13153da2bc7796260141df62378998d070207f"
 dependencies = [
  "cookie",
  "document-features",
@@ -2171,9 +2171,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "parking_lot"
@@ -3620,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "3.0.12"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
+checksum = "99ba1025f18a4a3fc3e9b48c868e9beb4f24f4b4b1a325bada26bd4119f46537"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
@@ -3636,14 +3636,14 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.3",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
+checksum = "60b4531c118335662134346048ddb0e54cc86bd7e81866757873055f0e38f5d2"
 dependencies = [
  "base64 0.22.1",
  "http",

--- a/clickhouse-arrow/Cargo.toml
+++ b/clickhouse-arrow/Cargo.toml
@@ -65,7 +65,7 @@ chrono-tz = "0.10"
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 indexmap = { version = "2" }
 lz4_flex = "0.11"
-opentelemetry-semantic-conventions = { version = "0.30", features = [
+opentelemetry-semantic-conventions = { version = "0.31", features = [
     "default",
     "semconv_experimental",
 ] }


### PR DESCRIPTION
## Summary
- bump opentelemetry-semantic-conventions to 0.31.0
- bump ureq to 3.1.2 (and transitives)

## Verification
- cargo +nightly fmt -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test -F test-utils -- --nocapture --show-output

Closes #57. Closes #50.