### PR TITLE
ci: refresh GitHub Actions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true
@@ -29,7 +29,7 @@ jobs:
   validate-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
- bump actions/checkout to v5
- bump actions/labeler to v6
- bump amannn/action-semantic-pull-request to v6
- bump softprops/action-gh-release to v2
- bump codecov/codecov-action to v6

Closes #44. Closes #42. Closes #41. Closes #6. Closes #2.