### PR TITLE
feat(pool): increase connection limit to 16, fix overflow bug

### DIFF
--- a/clickhouse-arrow/src/arrow/types.rs
+++ b/clickhouse-arrow/src/arrow/types.rs
@@ -1042,7 +1042,7 @@ mod tests {
         );
 
         // Setup: Create FieldRef instances for the schema
-        let fields = vec![
+        let fields = [
             Field::new("string_field", DataType::Utf8, false),
             Field::new("binary_field", DataType::Binary, false),
             Field::new("nullable_string_field", DataType::Utf8, true),


### PR DESCRIPTION
## Summary

Fixes an overflow bug in the `inner_pool` load balancer and increases the maximum connection limit from 4 to 16.

## The Problem

### Overflow Bug

The previous implementation used bit-packed 8-bit counters within a single `AtomicUsize`:

```rust
// Old implementation
let packed_load = AtomicUsize::new(0);
// Each connection gets 8 bits: [conn3|conn2|conn1|conn0]
```

Overflow occurs at 255 operations per connection. With operation weights:
- Query: 3
- Insert: 5  
- InsertMany: 7

This means 36 concurrent InsertMany operations before overflow causes the counter to wrap to 0, making the connection appear idle when under heavy load. This results in performance degradation as the overflowed connection gets additional work.

### Status Check Issue

The `status()` method only checked `connection[0]` even when `inner_pool` spawns 2-4 connections. A client could report `Open` status while 3/4 of its connections were dead.

## The Solution

### Array-Based Load Counters

Replaced bit-packed counters with an array of 64-bit counters:

```rust
// New implementation
struct AtomicLoad {
    load_counters: Box<[AtomicUsize]>,  // One counter per connection
    max_connections: u8,
}
```

Changes:
- Overflow limit: 2^64 operations
- Memory cost: 8 bytes → 128 bytes (16 connections × 8 bytes)
- Fits in single 128-byte cache line

### Fixed Status Reporting

`status()` now checks all connections and returns the worst status using `PartialOrd`/`Ord`:

```rust
let status = self.state.iter()
    .map(|swap| ConnectionStatus::from(...))
    .max()  // Error > Closed > Open
    .unwrap_or(ConnectionStatus::Closed);
```

### Increased Connection Limit

- Previous max: 4 connections
- New max: 16 connections
- Default: 4 (unchanged, backward compatible)
- Configurable via `fast_mode_size` option

## Testing

- 8 new unit tests covering:
  - Overflow scenarios with heavy operations
  - Deterministic key-based assignment
  - Least-loaded selection
  - Edge cases (zero weight, invalid index, boundary conditions)
  
- All existing tests pass:
  - 993/993 lib tests
  - 10/10 e2e tests
  
- Benchmarks verify performance:
  - Arrow format: 1.69ms for 10k rows
  - RowBinary: 19.33ms for 10k rows
  - Arrow is 11x faster

## Migration

No breaking changes. Default behavior unchanged (4 connections). Users can opt into higher connection counts by setting `fast_mode_size` up to 16.