### PR TITLE
fix: set 'default' database in ClientOptions

### DIFF
--- a/clickhouse-arrow/src/client/builder.rs
+++ b/clickhouse-arrow/src/client/builder.rs
@@ -1108,7 +1108,7 @@ mod tests {
         assert!(id.contains("example.com"));
 
         let empty_builder = default_builder();
-        assert_eq!(empty_builder.connection_identifier(), "default13933120620573868840");
+        assert_eq!(empty_builder.connection_identifier(), "default13933120620573868840default");
     }
 
     #[tokio::test]

--- a/clickhouse-arrow/src/client/options.rs
+++ b/clickhouse-arrow/src/client/options.rs
@@ -6,6 +6,9 @@ use super::CompressionMethod;
 use crate::native::protocol::ChunkedProtocolMode;
 use crate::prelude::Secret;
 
+/// Default database for queries
+pub const DEFAULT_DATABASE: &str = "default";
+
 /// Configuration options for a `ClickHouse` client connection and Arrow serialization.
 ///
 /// The `ClientOptions` struct defines the settings used to establish a connection
@@ -73,7 +76,7 @@ impl Default for ClientOptions {
         ClientOptions {
             username:         "default".to_string(),
             password:         Secret::new(""),
-            default_database: String::new(),
+            default_database: DEFAULT_DATABASE.to_string(),
             domain:           None,
             ipv4_only:        false,
             cafile:           None,


### PR DESCRIPTION
Methods like `fetch_schema` and similar ones used "" as the database name and returned an empty `HashMap` of schemas.