### PR TITLE
Fix no space available bug

### DIFF
--- a/clickhouse-arrow/src/constants.rs
+++ b/clickhouse-arrow/src/constants.rs
@@ -8,7 +8,7 @@ pub(super) const CONN_WRITE_BUFFER_DEFAULT: usize = 10 * 1024 * 1024;
 
 // 8MB send and receive buffer sizes
 pub(super) const TCP_READ_BUFFER_SIZE: u32 = 65536 * 2; // 16 * 1024; // 16KB
-pub(super) const TCP_WRITE_BUFFER_SIZE: u32 = 8 * 1024 * 1024; // 8MB
+pub(super) const TCP_WRITE_BUFFER_SIZE: u32 = 7 * 1024 * 1024; // 7MB
 // Connection, read, and write
 pub(super) const TCP_CONNECT_TIMEOUT: u64 = 30;
 // Keep alive


### PR DESCRIPTION
I encountered a weird error when trying to use this create on OSX (M4).
Creating a client would never succeed, yielding the following error message:

```
2026-02-02T13:14:13.984668Z ERROR clickhouse_arrow::client::connection: error=io error: No buffer space available (os error 55)
Error: io error: No buffer space available (os error 55)

Caused by:
    No buffer space available (os error 55)
```

Lowering the value of the `TCP_WRITE_BUFFER_SIZE` constant from 8MB to 7MB fixed the issue.