### PR TITLE
fix: cross-client type correctness + SerializationInfo Sparse reads

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -18,6 +18,14 @@ test:
     CLICKHOUSE_NATIVE_DEBUG_ARROW={{ ARROW_DEBUG }} RUST_LOG={{ LOG }} cargo test \
      -F test-utils -- --nocapture --show-output
 
+# Serial test runner (slower; avoids Docker container-start contention)
+test-serial:
+    # Disables both within-binary (--test-threads=1) and across-binary
+    # (--jobs 1) parallelism. Use when `just test` fails with
+    # WaitContainer(StartupTimeout) or Docker is under load.
+    CLICKHOUSE_NATIVE_DEBUG_ARROW={{ ARROW_DEBUG }} RUST_LOG={{ LOG }} cargo test \
+     --jobs 1 -F test-utils -- --nocapture --show-output --test-threads=1
+
 test-one test_name:
     CLICKHOUSE_NATIVE_DEBUG_ARROW={{ ARROW_DEBUG }} RUST_LOG={{ LOG }} cargo test \
      -F test-utils "{{ test_name }}" -- --nocapture --show-output

--- a/clickhouse-arrow/src/arrow/block.rs
+++ b/clickhouse-arrow/src/arrow/block.rs
@@ -530,6 +530,74 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_deserialize_rejects_unsupported_kind() {
+        // A column header that declares has_custom=1 and kind=2 (Detached) —
+        // a kind the arrow reader does not support. It must be rejected with
+        // Error::Protocol, not silently mis-framed.
+        let mut buffer = Vec::new();
+        BlockInfo::default().write_async(&mut buffer).await.unwrap();
+        buffer.write_var_uint(1).await.unwrap(); // Columns
+        buffer.write_var_uint(1).await.unwrap(); // Rows
+        buffer.write_string("v").await.unwrap();
+        buffer.write_string("Int32").await.unwrap();
+        buffer.write_u8(1).await.unwrap(); // has_custom = 1
+        buffer.write_u8(2).await.unwrap(); // kind = 2 (Detached)
+
+        let mut state = DeserializerState::default();
+        let mut reader = Cursor::new(buffer);
+        let result = RecordBatch::read_async(
+            &mut reader,
+            DBMS_TCP_PROTOCOL_VERSION,
+            ArrowOptions::default(),
+            &mut state,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(Error::Protocol(m)) if m.contains("unsupported SerializationInfo kind")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_deserialize_sparse_all_default_column() {
+        // A single-row Int32 column serialized Sparse where the only row is
+        // the default (0). The SparseOffsets stream is just the terminator
+        // (END_OF_GRANULE_FLAG | group_size=1 trailing default), and there are
+        // zero non-default values. Exercises the Sparse dispatch + materialize
+        // path end-to-end through the block reader.
+        const END_OF_GRANULE_FLAG: u64 = 1u64 << 62;
+
+        let mut buffer = Vec::new();
+        BlockInfo::default().write_async(&mut buffer).await.unwrap();
+        buffer.write_var_uint(1).await.unwrap(); // Columns
+        buffer.write_var_uint(1).await.unwrap(); // Rows
+        buffer.write_string("v").await.unwrap();
+        buffer.write_string("Int32").await.unwrap();
+        buffer.write_u8(1).await.unwrap(); // has_custom = 1
+        buffer.write_u8(1).await.unwrap(); // kind = 1 (Sparse)
+        // SparseOffsets: one flagged terminator = "1 trailing default, no value".
+        buffer.write_var_uint(END_OF_GRANULE_FLAG | 1).await.unwrap();
+        // SparseElements: zero non-default Int32 values follow.
+
+        let mut state = DeserializerState::default();
+        let mut reader = Cursor::new(buffer);
+        let batch = RecordBatch::read_async(
+            &mut reader,
+            DBMS_TCP_PROTOCOL_VERSION,
+            ArrowOptions::default(),
+            &mut state,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(batch.num_rows(), 1);
+        assert_eq!(batch.num_columns(), 1);
+        let col = batch.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(col.null_count(), 0);
+        assert_eq!(col.value(0), 0, "the single sparse-default row materializes as 0");
+    }
+
+    #[tokio::test]
     async fn test_deserialize_malformed_input() {
         let mut buffer = Vec::new();
         BlockInfo::default().write_async(&mut buffer).await.unwrap(); // BlockInfo
@@ -1707,6 +1775,34 @@ mod tests_sync {
             result,
             Err(Error::TypeParseError(m))
             if &m == "invalid type name: 'InvalidType'"
+        ));
+    }
+
+    #[test]
+    fn test_deserialize_sync_rejects_non_default_kind() {
+        // The sync arrow read path has no sparse-aware decoder, so any
+        // non-Default kind (here kind=1, Sparse) must surface a protocol error
+        // rather than mis-frame the dense body.
+        let mut buffer = Vec::new();
+        BlockInfo::default().write(&mut buffer).unwrap();
+        buffer.put_var_uint(1).unwrap(); // Columns
+        buffer.put_var_uint(1).unwrap(); // Rows
+        buffer.put_string("v").unwrap();
+        buffer.put_string("Int32").unwrap();
+        buffer.put_u8(1); // has_custom = 1
+        buffer.put_u8(1); // kind = 1 (Sparse)
+
+        let mut state = DeserializerState::default();
+        let mut reader = Cursor::new(buffer);
+        let result = RecordBatch::read(
+            &mut reader,
+            DBMS_TCP_PROTOCOL_VERSION,
+            ArrowOptions::default(),
+            &mut state,
+        );
+        assert!(matches!(
+            result,
+            Err(Error::Protocol(m)) if m.contains("on sync read path is not implemented")
         ));
     }
 

--- a/clickhouse-arrow/src/arrow/block.rs
+++ b/clickhouse-arrow/src/arrow/block.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use arrow::array::{Array, new_empty_array};
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 
 use super::builder::TypedBuilder;
 use super::deserialize::{ArrowDeserializerState, ClickHouseArrowDeserializer};
@@ -21,10 +21,12 @@ use crate::formats::{DeserializerState, SerializerState};
 use crate::geo::normalize_geo_type;
 use crate::io::{ClickHouseBytesRead, ClickHouseBytesWrite, ClickHouseRead, ClickHouseWrite};
 use crate::native::block_info::BlockInfo;
-use crate::native::protocol::DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION;
+use crate::native::kinds::{
+    SerializationKind, read_serialization_kind, read_serialization_kind_sync,
+};
 use crate::prelude::*;
 use crate::serialize::ClickHouseNativeSerializer;
-use crate::{ArrowOptions, Result, Type};
+use crate::{ArrowOptions, Error, Result, Type};
 
 /// Implementation of `ProtocolData` for Arrow `RecordBatch`es.
 ///
@@ -235,11 +237,10 @@ impl ProtocolData<RecordBatch, ArrowDeserializerState> for RecordBatch {
                 trace!(?field, ?type_hint, ?options, "deserializing column {i}");
             }
 
-            let _has_custom = if revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION {
-                reader.read_u8().await? != 0
-            } else {
-                false
-            };
+            // Per-column SerializationInfo kind stack (gated on
+            // DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION). See
+            // crate::native::protocol for the dialect we declare.
+            let kind = read_serialization_kind(reader, revision).await?;
 
             let array = if rows > 0 {
                 let dt = field.data_type();
@@ -252,11 +253,40 @@ impl ProtocolData<RecordBatch, ArrowDeserializerState> for RecordBatch {
                 };
 
                 let row_buffer = &mut deser.buffer;
-                type_hint.deserialize_prefix_async(reader, &mut prefix_state).await?;
-                type_hint
-                    .deserialize_arrow_async(builder, reader, dt, rows, &[], row_buffer)
-                    .await
-                    .inspect_err(|error| error!(?error, ?field, "col {i} deserialize"))?
+                match kind {
+                    SerializationKind::Default => {
+                        type_hint.deserialize_prefix_async(reader, &mut prefix_state).await?;
+                        type_hint
+                            .deserialize_arrow_async(builder, reader, dt, rows, &[], row_buffer)
+                            .await
+                            .inspect_err(|error| {
+                                error!(?error, ?field, "col {i} deserialize");
+                            })?
+                    }
+                    SerializationKind::Sparse => {
+                        crate::arrow::deserialize::sparse::deserialize_async(
+                            &type_hint,
+                            reader,
+                            dt,
+                            field.is_nullable(),
+                            rows,
+                            &[],
+                            row_buffer,
+                            &mut prefix_state,
+                        )
+                        .await
+                        .inspect_err(|error| {
+                            error!(?error, ?field, "col {i} sparse deserialize");
+                        })?
+                    }
+                    other => {
+                        return Err(Error::Protocol(format!(
+                            "unsupported SerializationInfo kind for column {:?}: {:?}",
+                            field.name(),
+                            other,
+                        )));
+                    }
+                }
             } else {
                 new_empty_array(field.data_type())
             };
@@ -308,12 +338,7 @@ impl ProtocolData<RecordBatch, ArrowDeserializerState> for RecordBatch {
                 trace!(?field, ?type_hint, ?options, "deserializing column {i}");
             }
 
-            // TODO: Ignored - pass this to prefix deserialization
-            let _has_custom = if revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION {
-                reader.try_get_u8()? != 0
-            } else {
-                false
-            };
+            let kind = read_serialization_kind_sync(reader, revision)?;
 
             let array = if rows > 0 {
                 let dt = field.data_type();
@@ -326,10 +351,32 @@ impl ProtocolData<RecordBatch, ArrowDeserializerState> for RecordBatch {
                     builders.last_mut().unwrap()
                 };
 
-                type_hint.deserialize_prefix(reader)?;
-                type_hint
-                    .deserialize_arrow(builder, reader, dt, rows, &[], &mut deser.buffer)
-                    .inspect_err(|error| error!(?error, ?type_hint, ?field, "deserialize {i}"))?
+                match kind {
+                    SerializationKind::Default => {
+                        type_hint.deserialize_prefix(reader)?;
+                        type_hint
+                            .deserialize_arrow(builder, reader, dt, rows, &[], &mut deser.buffer)
+                            .inspect_err(|error| {
+                                error!(?error, ?type_hint, ?field, "deserialize {i}");
+                            })?
+                    }
+                    // Sparse on the sync path: the body wire format is the
+                    // same as async (offsets stream then nested values),
+                    // but the existing sync deserialize_prefix /
+                    // deserialize_arrow API doesn't compose for the
+                    // recursive nested call as cleanly. Sync clients
+                    // running against post-54465 servers should expect
+                    // this to surface; the async path is the primary
+                    // production target.
+                    other => {
+                        return Err(Error::Protocol(format!(
+                            "SerializationInfo kind {:?} on sync read path is not implemented \
+                             (column {:?}); switch to the async client for sparse-aware reads",
+                            other,
+                            field.name(),
+                        )));
+                    }
+                }
             } else {
                 new_empty_array(field.data_type())
             };

--- a/clickhouse-arrow/src/arrow/deserialize.rs
+++ b/clickhouse-arrow/src/arrow/deserialize.rs
@@ -17,6 +17,7 @@ mod low_cardinality;
 mod map;
 mod null;
 mod primitive;
+pub(crate) mod sparse;
 mod tuple;
 
 use std::sync::Arc;
@@ -459,7 +460,7 @@ impl ClickHouseArrowDeserializer for Type {
                     Type::Ipv4 => i => { opt_value!(ok => b, i, nulls, binary!(Ipv4 => reader)) },
                     Type::Ipv6 => i => { opt_value!(ok => b, i, nulls, binary!(Ipv6 => reader)) },
                     Type::Uuid => i => {
-                        opt_value!(ok => b, i, nulls, binary!(Fixed(16) => reader))
+                        opt_value!(ok => b, i, nulls, binary!(Uuid => reader))
                     },
                     // Special numeric types that need to be read as bytes
                     Type::Int128 | Type::UInt128 => i => {

--- a/clickhouse-arrow/src/arrow/deserialize/binary.rs
+++ b/clickhouse-arrow/src/arrow/deserialize/binary.rs
@@ -75,6 +75,18 @@ macro_rules! binary {
             std::net::Ipv6Addr::from(octets).octets()
         }
     }};
+    // CH writes UUID as a 128-bit value stored as two little-endian u64s
+    // in (high, low) order. Reverse each 8-byte half independently to land
+    // in canonical RFC 4122 byte order.
+    (Uuid => $reader:expr) => {{
+        {
+            let mut buf = [0u8; 16];
+            $reader.try_copy_to_slice(&mut buf)?;
+            buf[0..8].reverse();
+            buf[8..16].reverse();
+            buf
+        }
+    }};
 }
 pub(crate) use binary;
 
@@ -132,6 +144,16 @@ macro_rules! binary_async {
             let mut octets = [0u8; 16];
             let _ = $reader.read_exact(&mut octets[..]).await?;
             std::net::Ipv6Addr::from(octets).octets()
+        }
+    }};
+    // See sync `Uuid` arm — CH wire is two LE u64s in (high, low) order.
+    (Uuid => $reader:expr) => {{
+        {
+            let mut buf = [0u8; 16];
+            let _ = $reader.read_exact(&mut buf).await?;
+            buf[0..8].reverse();
+            buf[8..16].reverse();
+            buf
         }
     }};
 }
@@ -243,7 +265,13 @@ pub(crate) async fn deserialize_async<R: ClickHouseRead>(
                 }
                 Arc::new(b.finish())
             },
-            Type::Uuid | Type::Int128 | Type::UInt128 => {
+            Type::Uuid => {
+                for i in 0..rows {
+                   super::opt_value!(ok => b, i, nulls, binary_async!(Uuid => reader));
+                }
+                Arc::new(b.finish())
+            },
+            Type::Int128 | Type::UInt128 => {
                 for i in 0..rows {
                    super::opt_value!(ok => b, i, nulls, binary_async!(Fixed(16) => reader));
                 }
@@ -494,11 +522,18 @@ mod tests {
         let type_hint = Type::Uuid;
         let rows = 2;
         let null_mask = vec![];
+        // CH wire form: each UUID is a 128-bit LE value stored as two LE
+        // u64s in (high, low) order. The deserializer reverses each 8-byte
+        // half so the Arrow FixedSizeBinary(16) ends up in canonical RFC
+        // 4122 byte order.
         let input = vec![
-            // UUIDs: [00010203-0405-0607-0809-0a0b0c0d0e0f, 10111213-1415-1617-1819-1a1b1c1d1e1f]
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
-            0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
-            0x1c, 0x1d, 0x1e, 0x1f,
+            // wire (per 8-byte half, little-endian) -> arrow bytes:
+            // 0706050403020100 0f0e0d0c0b0a0908 -> 00010203-0405-0607-0809-0a0b0c0d0e0f
+            0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a,
+            0x09, 0x08,
+            // 1716151413121110 1f1e1d1c1b1a1918 -> 10111213-1415-1617-1819-1a1b1c1d1e1f
+            0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x1f, 0x1e, 0x1d, 0x1c, 0x1b, 0x1a,
+            0x19, 0x18,
         ];
         let mut reader = Cursor::new(input);
 
@@ -526,14 +561,15 @@ mod tests {
         let type_hint = Type::Nullable(Box::new(Type::Uuid));
         let rows = 3;
         let null_mask = vec![0, 1, 0]; // [not null, null, not null]
+        // Wire bytes are per-8-byte-half little-endian; the deserializer
+        // reverses each half so the Arrow value is canonical big-endian.
         let input = vec![
-            // UUIDs: [00010203-0405-0607-0809-0a0b0c0d0e0f, [0;16],
-            // 10111213-1415-1617-1819-1a1b1c1d1e1f]
-            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
-            0x0e, 0x0f, // non-null
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // null (zeroed)
-            0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d,
-            0x1e, 0x1f, // non-null
+            // wire -> arrow 00010203-0405-0607-0809-0a0b0c0d0e0f
+            0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a,
+            0x09, 0x08, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // null (zeroed)
+            // wire -> arrow 10111213-1415-1617-1819-1a1b1c1d1e1f
+            0x17, 0x16, 0x15, 0x14, 0x13, 0x12, 0x11, 0x10, 0x1f, 0x1e, 0x1d, 0x1c, 0x1b, 0x1a,
+            0x19, 0x18,
         ];
         let mut reader = Cursor::new(input);
 

--- a/clickhouse-arrow/src/arrow/deserialize/primitive.rs
+++ b/clickhouse-arrow/src/arrow/deserialize/primitive.rs
@@ -58,12 +58,8 @@ macro_rules! primitive {
     (Float32 => $reader:expr) => {{ $reader.try_get_f32_le()? }};
     (Float64 => $reader:expr) => {{ $reader.try_get_f64_le()? }};
     (Date => $reader:expr) => {{ $reader.try_get_u16_le().map(i32::from)? }};
-    (Date32 => $reader:expr) => {{
-        {
-            let days = $reader.try_get_i32_le()?;
-            days - $crate::deserialize::DAYS_1900_TO_1970 // Adjust to days since 1970-01-01
-        }
-    }};
+    // CH Date32 wire format is days-since-1970 (signed i32), same epoch as Arrow Date32.
+    (Date32 => $reader:expr) => {{ $reader.try_get_i32_le()? }};
     (DateTime => $reader:expr) => {{ $reader.try_get_u32_le().map(i64::from)? }};
     (DateTime64(0) => $reader:expr) => {{ $reader.try_get_i64_le()? }};
     (DateTime64(3) => $reader:expr) => {{ $reader.try_get_i64_le()? }};
@@ -103,12 +99,8 @@ macro_rules! primitive_async {
     (Float32 => $reader:expr) => {{ $reader.read_f32_le().await? }};
     (Float64 => $reader:expr) => {{ $reader.read_f64_le().await? }};
     (Date => $reader:expr) => {{ $reader.read_u16_le().await?.map(i32::from)? }};
-    (Date32 => $reader:expr) => {{
-        {
-            let days = $reader.read_i32_le().await?;
-            days - $crate::deserialize::DAYS_1900_TO_1970 // Adjust to days since 1970-01-01
-        }
-    }};
+    // CH Date32 wire format is days-since-1970 (signed i32), same epoch as Arrow Date32.
+    (Date32 => $reader:expr) => {{ $reader.read_i32_le().await? }};
     (DateTime => $reader:expr) => {{ $reader.read_u32_le().await?.map(i64::from)? }};
     (DateTime64(0) => $reader:expr) => {{ $reader.read_i64_le().await? }};
     (DateTime64(3) => $reader:expr) => {{ $reader.read_i64_le().await? }};

--- a/clickhouse-arrow/src/arrow/deserialize/sparse.rs
+++ b/clickhouse-arrow/src/arrow/deserialize/sparse.rs
@@ -1,0 +1,451 @@
+//! Sparse column deserialization.
+//!
+//! `ClickHouse` uses sparse serialization for columns whose values are
+//! mostly equal to their type's default. The wire format follows the
+//! per-column kind-stack byte and consists of two streams:
+//!
+//! 1. **`SparseOffsets`** — a sequence of varints, matching CH's `deserializeOffsets`. Each
+//!    varint's low 62 bits are a "group size": the count of default rows in this group. Bit 62
+//!    (`END_OF_GRANULE_FLAG`) marks the terminating entry of the stream. A *non-terminating* entry
+//!    means "`group_size` defaults, then exactly one non-default value"; the *terminating*
+//!    (flagged) entry means "`group_size` trailing defaults, and no value follows". CH always
+//!    writes a final flagged entry, so the loop is driven by the flag bit — not by a row count.
+//!    Stopping early on a row-count match leaves the terminator unread and desyncs the next column
+//!    body.
+//!
+//! 2. **`SparseElements`** — the nested type's body, holding exactly N values (where N is the
+//!    number of non-default rows discovered in the offsets stream).
+//!
+//! On read we:
+//!  - decode the offsets into a `Vec<u64>` of absolute non-default row positions in `0..rows`
+//!  - deserialize the N nested values into a temporary Arrow array via the standard dense path
+//!  - **materialize** a full-row Arrow array by walking row-by-row, appending the type's default at
+//!    default rows and copying from the nested array at non-default rows.
+//!
+//! Sparse for `Nullable(T)` is the same shape, but the null map is
+//! reconstructed implicitly from the offsets: default rows are null,
+//! non-default rows take the nested value (which may itself be null
+//! per the nested null map).
+
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::datatypes::*;
+
+use super::ClickHouseArrowDeserializer;
+use crate::arrow::builder::TypedBuilder;
+use crate::deserialize::ClickHouseNativeDeserializer;
+use crate::formats::DeserializerState;
+use crate::io::ClickHouseRead;
+use crate::{Error, Result, Type};
+
+/// High bit on a sparse-offset varint marks the last entry of a CH
+/// serialization granule. We don't model granules at the protocol-block
+/// layer, but the byte is still set on the last varint so we mask it
+/// off before treating the value as a count.
+const END_OF_GRANULE_FLAG: u64 = 1u64 << 62;
+
+/// Read the `SparseOffsets` stream, returning the sorted absolute row
+/// indices of the non-default values.
+///
+/// Mirrors CH's `deserializeOffsets`: read varints until the flagged
+/// (`END_OF_GRANULE_FLAG`) terminator is consumed. A non-flagged entry is
+/// `group_size` defaults then one non-default value at the resulting
+/// position; the flagged entry is `group_size` trailing defaults with no
+/// value after it. The terminator is always present on the wire, so the
+/// loop must run until it is read — leaving it unread desyncs the next
+/// column body (manifesting as a bogus compression-block header).
+///
+/// `rows` is used only as a sanity bound; the flag, not the row count,
+/// terminates the stream.
+async fn read_offsets<R: ClickHouseRead>(reader: &mut R, rows: usize) -> Result<Vec<u64>> {
+    let mut offsets = Vec::new();
+    let mut position: u64 = 0;
+    let total = rows as u64;
+
+    loop {
+        let raw = reader.read_var_uint().await?;
+        let end_of_granule = raw & END_OF_GRANULE_FLAG != 0;
+        let group_size = raw & !END_OF_GRANULE_FLAG;
+
+        position = position
+            .checked_add(group_size)
+            .ok_or_else(|| Error::Protocol("sparse offsets overflow".into()))?;
+
+        if end_of_granule {
+            // Terminating entry: `group_size` trailing defaults, no value.
+            break;
+        }
+
+        // Non-terminating entry: a non-default value sits at `position`.
+        if position >= total {
+            return Err(Error::Protocol(format!(
+                "sparse offset points past row count: position={position} total={total}"
+            )));
+        }
+        offsets.push(position);
+        position += 1;
+    }
+
+    if position > total {
+        return Err(Error::Protocol(format!(
+            "sparse offsets overshot row count: position={position} total={total}"
+        )));
+    }
+
+    Ok(offsets)
+}
+
+/// Deserialize a sparse column to a full-row dense Arrow array.
+///
+/// Reads the offsets stream, then reads N non-default values into a
+/// temporary array via the standard dense path, then materializes a
+/// full-row column by interleaving defaults and non-default values.
+///
+/// Note there is no `builder` parameter (unlike the dense
+/// `deserialize_arrow_async` path): the result is built entirely from the
+/// interleave output, and the nested values are read into a fresh
+/// builder sized for the non-default count. The caller uses the returned
+/// `ArrayRef` directly.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn deserialize_async<R: ClickHouseRead>(
+    type_hint: &Type,
+    reader: &mut R,
+    data_type: &DataType,
+    is_nullable: bool,
+    rows: usize,
+    nulls: &[u8],
+    rbuffer: &mut Vec<u8>,
+    prefix_state: &mut DeserializerState,
+) -> Result<ArrayRef> {
+    if rows == 0 {
+        return Ok(new_empty_array(data_type));
+    }
+
+    let offsets = read_offsets(reader, rows).await?;
+    let num_nondefault = offsets.len();
+
+    // Read the dense nested values into a fresh builder sized for the
+    // non-default count (the caller's full-`rows` builder is not used on
+    // this path; see the function doc).
+    let mut nested_builder = TypedBuilder::try_new(type_hint, data_type)?;
+    // Sparse values stream still carries the type's prefix once.
+    type_hint.deserialize_prefix_async(reader, prefix_state).await?;
+    let nested_array = type_hint
+        .deserialize_arrow_async(
+            &mut nested_builder,
+            reader,
+            data_type,
+            num_nondefault,
+            nulls,
+            rbuffer,
+        )
+        .await?;
+
+    // Walk row-by-row, scattering nested values at non-default positions
+    // and filling everything else with the type's default.
+    materialize(data_type, is_nullable, rows, &offsets, &nested_array)
+}
+
+/// Build the full-row array by interleaving the type's default with
+/// values from `nested` at the rows listed in `offsets`.
+fn materialize(
+    data_type: &DataType,
+    is_nullable: bool,
+    rows: usize,
+    offsets: &[u64],
+    nested: &ArrayRef,
+) -> Result<ArrayRef> {
+    // Strategy: use arrow::compute::interleave to splice together a
+    // single-row "default" array and the nested values. This sidesteps
+    // per-builder-variant scatter code and works uniformly for every
+    // Arrow type (incl. Strings, FixedSizeBinary, Lists, etc.).
+    use arrow::compute::interleave;
+
+    let default_array = default_array_of(data_type, is_nullable)?;
+    let arrays: [&dyn Array; 2] = [default_array.as_ref(), nested.as_ref()];
+
+    // Build the (source_idx, row_idx) plan: at each output row, either
+    // index 0 of `default_array` or the n-th value of `nested`.
+    let mut indices: Vec<(usize, usize)> = Vec::with_capacity(rows);
+    let mut nondefault_iter = offsets.iter().copied().peekable();
+    let mut next_nested: usize = 0;
+    for row in 0..(rows as u64) {
+        if nondefault_iter.peek() == Some(&row) {
+            let _ = nondefault_iter.next();
+            indices.push((1, next_nested));
+            next_nested += 1;
+        } else {
+            indices.push((0, 0));
+        }
+    }
+
+    let materialized = interleave(&arrays, &indices)
+        .map_err(|e| Error::ArrowDeserialize(format!("sparse interleave failed: {e}")))?;
+
+    Ok(materialized)
+}
+
+/// One-row array carrying the row value used at the omitted (default)
+/// positions of a sparse column.
+///
+/// - When the column is **nullable**, the omitted rows are the `Nullable` default, which is NULL.
+///   `new_null_array` produces that uniformly for every Arrow type, so we short-circuit there.
+/// - When the column is **non-nullable**, the omitted rows are the underlying type's *zero*
+///   (numeric 0, empty string/binary, epoch timestamp, zero-scaled decimal, …). We build that
+///   explicitly per type; emitting a NULL here would inject nulls into a non-nullable column and
+///   `RecordBatch::try_new` would reject the batch.
+///
+/// The returned array's `DataType` matches `data_type` exactly (including
+/// decimal precision/scale and timestamp unit/timezone) so the caller's
+/// `interleave` against the nested values array does not hit a
+/// type-mismatch.
+///
+/// A genuinely unsupported non-nullable type is a hard `Error::Protocol`
+/// rather than a silent NULL fill — consistent with the dialect note in
+/// [`crate::native::protocol`]: we don't fabricate values we can't
+/// represent correctly.
+fn default_array_of(data_type: &DataType, is_nullable: bool) -> Result<ArrayRef> {
+    use arrow::array::new_null_array;
+
+    // Nullable column: the default cell is null, uniformly across types.
+    if is_nullable {
+        return Ok(new_null_array(data_type, 1));
+    }
+
+    // Non-nullable column: build the type's zero. interleave demands the
+    // default array carry the same DataType as the nested values, so the
+    // decimal/timestamp arms re-apply precision/scale and unit/timezone.
+    Ok(match data_type {
+        DataType::Int8 => Arc::new(Int8Array::from(vec![0_i8])),
+        DataType::Int16 => Arc::new(Int16Array::from(vec![0_i16])),
+        DataType::Int32 => Arc::new(Int32Array::from(vec![0_i32])),
+        DataType::Int64 => Arc::new(Int64Array::from(vec![0_i64])),
+        DataType::UInt8 => Arc::new(UInt8Array::from(vec![0_u8])),
+        DataType::UInt16 => Arc::new(UInt16Array::from(vec![0_u16])),
+        DataType::UInt32 => Arc::new(UInt32Array::from(vec![0_u32])),
+        DataType::UInt64 => Arc::new(UInt64Array::from(vec![0_u64])),
+        DataType::Float32 => Arc::new(Float32Array::from(vec![0.0_f32])),
+        DataType::Float64 => Arc::new(Float64Array::from(vec![0.0_f64])),
+        DataType::Boolean => Arc::new(BooleanArray::from(vec![false])),
+        DataType::Date32 => Arc::new(Date32Array::from(vec![0_i32])),
+        DataType::Date64 => Arc::new(Date64Array::from(vec![0_i64])),
+        DataType::Utf8 => Arc::new(StringArray::from(vec![""])),
+        DataType::LargeUtf8 => Arc::new(LargeStringArray::from(vec![""])),
+        DataType::Binary => Arc::new(BinaryArray::from(vec![&b""[..]])),
+        DataType::LargeBinary => Arc::new(LargeBinaryArray::from(vec![&b""[..]])),
+        DataType::FixedSizeBinary(n) => {
+            let zeros = vec![0u8; usize::try_from(*n).unwrap_or(0)];
+            Arc::new(
+                FixedSizeBinaryArray::try_from_iter(std::iter::once(zeros.as_slice()))
+                    .map_err(|e| Error::ArrowDeserialize(format!("fixed bin default: {e}")))?,
+            )
+        }
+        // Decimal: zero mantissa, preserving precision/scale so interleave
+        // sees a matching DataType.
+        DataType::Decimal128(p, s) => Arc::new(
+            Decimal128Array::from(vec![0_i128])
+                .with_precision_and_scale(*p, *s)
+                .map_err(|e| Error::ArrowDeserialize(format!("decimal128 default: {e}")))?,
+        ),
+        DataType::Decimal256(p, s) => Arc::new(
+            Decimal256Array::from(vec![i256::ZERO])
+                .with_precision_and_scale(*p, *s)
+                .map_err(|e| Error::ArrowDeserialize(format!("decimal256 default: {e}")))?,
+        ),
+        // Timestamp: epoch (0), preserving unit + timezone metadata.
+        DataType::Timestamp(unit, tz) => {
+            let arr: ArrayRef = match unit {
+                TimeUnit::Second => Arc::new(TimestampSecondArray::from(vec![0_i64])),
+                TimeUnit::Millisecond => Arc::new(TimestampMillisecondArray::from(vec![0_i64])),
+                TimeUnit::Microsecond => Arc::new(TimestampMicrosecondArray::from(vec![0_i64])),
+                TimeUnit::Nanosecond => Arc::new(TimestampNanosecondArray::from(vec![0_i64])),
+            };
+            // Re-attach the timezone via cast so the DataType matches the
+            // nested values exactly.
+            if tz.is_some() {
+                arrow::compute::cast(&arr, data_type)
+                    .map_err(|e| Error::ArrowDeserialize(format!("timestamp tz default: {e}")))?
+            } else {
+                arr
+            }
+        }
+        DataType::Time32(TimeUnit::Second) => Arc::new(Time32SecondArray::from(vec![0_i32])),
+        DataType::Time32(TimeUnit::Millisecond) => {
+            Arc::new(Time32MillisecondArray::from(vec![0_i32]))
+        }
+        DataType::Time64(TimeUnit::Microsecond) => {
+            Arc::new(Time64MicrosecondArray::from(vec![0_i64]))
+        }
+        DataType::Time64(TimeUnit::Nanosecond) => {
+            Arc::new(Time64NanosecondArray::from(vec![0_i64]))
+        }
+        DataType::Duration(TimeUnit::Second) => Arc::new(DurationSecondArray::from(vec![0_i64])),
+        DataType::Duration(TimeUnit::Millisecond) => {
+            Arc::new(DurationMillisecondArray::from(vec![0_i64]))
+        }
+        DataType::Duration(TimeUnit::Microsecond) => {
+            Arc::new(DurationMicrosecondArray::from(vec![0_i64]))
+        }
+        DataType::Duration(TimeUnit::Nanosecond) => {
+            Arc::new(DurationNanosecondArray::from(vec![0_i64]))
+        }
+        // We do not fabricate a zero we can't represent faithfully for a
+        // non-nullable column; surface it loudly instead of corrupting.
+        other => {
+            return Err(Error::Protocol(format!(
+                "sparse default materialization not implemented for non-nullable type {other:?}"
+            )));
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    /// LEB128-encode a varint the same way CH's `write_var_uint` does, so
+    /// the fixtures `read_offsets` consumes are byte-identical to the wire.
+    fn push_varint(buf: &mut Vec<u8>, mut value: u64) {
+        loop {
+            let mut byte = (value & 0x7F) as u8;
+            value >>= 7;
+            if value > 0 {
+                byte |= 0x80;
+            }
+            buf.push(byte);
+            if value == 0 {
+                break;
+            }
+        }
+    }
+
+    /// Encode a `SparseOffsets` stream from `(group_size, end_of_granule)`
+    /// entries. The caller spells out the exact wire entries — including
+    /// the mandatory final flagged terminator — so the test pins the
+    /// format, not our own helper's idea of it.
+    fn encode_offsets(entries: &[(u64, bool)]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for &(group, end) in entries {
+            let raw = if end { group | END_OF_GRANULE_FLAG } else { group };
+            push_varint(&mut buf, raw);
+        }
+        buf
+    }
+
+    async fn read_offsets_from(entries: &[(u64, bool)], rows: usize) -> Result<Vec<u64>> {
+        let bytes = encode_offsets(entries);
+        let mut reader = Cursor::new(bytes);
+        read_offsets(&mut reader, rows).await
+    }
+
+    #[tokio::test]
+    async fn offsets_all_default() {
+        // 5 rows, all default: a single flagged terminator with the full
+        // trailing-default run and no values.
+        let offsets = read_offsets_from(&[(5, true)], 5).await.unwrap();
+        assert!(offsets.is_empty());
+    }
+
+    #[tokio::test]
+    async fn offsets_ends_with_default() {
+        // 8 rows: value at index 2, value at index 4, then defaults to the
+        // end. Groups: 2 defaults+value (idx 2), 1 default+value (idx 4),
+        // terminator with 3 trailing defaults.
+        let offsets = read_offsets_from(&[(2, false), (1, false), (3, true)], 8).await.unwrap();
+        assert_eq!(offsets, vec![2, 4]);
+    }
+
+    #[tokio::test]
+    async fn offsets_ends_with_nondefault() {
+        // 5 rows: value at index 4 is the last row. CH still writes a
+        // flagged terminator, here with group_size 0 (no trailing
+        // defaults). Dropping it would desync the next column.
+        let offsets = read_offsets_from(&[(4, false), (0, true)], 5).await.unwrap();
+        assert_eq!(offsets, vec![4]);
+    }
+
+    #[tokio::test]
+    async fn offsets_dense_all_nondefault() {
+        // Every row non-default (sparse is still legal here): a value at
+        // each index 0..3, then the zero-trailing terminator.
+        let offsets =
+            read_offsets_from(&[(0, false), (0, false), (0, false), (0, true)], 3).await.unwrap();
+        assert_eq!(offsets, vec![0, 1, 2]);
+    }
+
+    #[tokio::test]
+    async fn offsets_value_past_rows_is_error() {
+        // A non-terminating entry whose value would land at/after the row
+        // count is a malformed stream, not a silent truncation.
+        let err = read_offsets_from(&[(5, false), (0, true)], 5).await.unwrap_err();
+        assert!(matches!(err, Error::Protocol(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn default_nullable_is_null_for_any_type() {
+        // The nullable branch must short-circuit to a null cell even for a
+        // type that has no explicit zero arm (e.g. Decimal with odd scale).
+        let dt = DataType::Decimal128(38, 10);
+        let arr = default_array_of(&dt, true).unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr.null_count(), 1);
+        assert_eq!(arr.data_type(), &dt);
+    }
+
+    #[test]
+    fn default_non_nullable_decimal_is_zero() {
+        let dt = DataType::Decimal128(18, 4);
+        let arr = default_array_of(&dt, false).unwrap();
+        assert_eq!(arr.null_count(), 0);
+        assert_eq!(arr.data_type(), &dt, "precision/scale must survive for interleave");
+        let dec = arr.as_any().downcast_ref::<Decimal128Array>().unwrap();
+        assert_eq!(dec.value(0), 0_i128);
+    }
+
+    #[test]
+    fn default_non_nullable_timestamp_preserves_unit_and_tz() {
+        let dt = DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("UTC")));
+        let arr = default_array_of(&dt, false).unwrap();
+        assert_eq!(arr.null_count(), 0);
+        assert_eq!(arr.data_type(), &dt, "unit + tz must match the nested values' DataType");
+        let ts = arr.as_any().downcast_ref::<TimestampMillisecondArray>().unwrap();
+        assert_eq!(ts.value(0), 0_i64);
+    }
+
+    #[test]
+    fn default_non_nullable_unsupported_type_errors() {
+        // A non-nullable type with no zero arm must fail loud rather than
+        // inject a null into a non-nullable column.
+        let dt = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+        let err = default_array_of(&dt, false).unwrap_err();
+        assert!(matches!(err, Error::Protocol(_)), "got {err:?}");
+    }
+
+    #[test]
+    fn materialize_scatters_values_and_fills_zero_defaults() {
+        // Non-nullable Int32, 5 rows, non-default values 10 and 20 at
+        // positions 1 and 3. Default rows must be 0, not null.
+        let dt = DataType::Int32;
+        let nested: ArrayRef = Arc::new(Int32Array::from(vec![10, 20]));
+        let out = materialize(&dt, false, 5, &[1, 3], &nested).unwrap();
+        assert_eq!(out.null_count(), 0);
+        let ints = out.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(ints.values(), &[0, 10, 0, 20, 0]);
+    }
+
+    #[test]
+    fn materialize_nullable_defaults_are_null() {
+        // Nullable Int32: default rows are null, non-default rows carry the
+        // nested value.
+        let dt = DataType::Int32;
+        let nested: ArrayRef = Arc::new(Int32Array::from(vec![10, 20]));
+        let out = materialize(&dt, true, 5, &[1, 3], &nested).unwrap();
+        let ints = out.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert!(ints.is_null(0) && ints.is_null(2) && ints.is_null(4));
+        assert_eq!(ints.value(1), 10);
+        assert_eq!(ints.value(3), 20);
+    }
+}

--- a/clickhouse-arrow/src/arrow/serialize/primitive.rs
+++ b/clickhouse-arrow/src/arrow/serialize/primitive.rs
@@ -716,12 +716,9 @@ write_primitive_values!(write_date_values, scalar u16::default(), write_u16_le, 
         Ok::<_, Error>(v as u16) // Days since epoch
     })
 ]);
+// CH Date32 wire format is days-since-1970 (signed i32), same epoch as Arrow Date32.
 write_primitive_values!(write_date32_values, scalar i32::default(), write_i32_le, [
-    (Date32Array, |v: i32| {
-        const DAYS_1900_TO_1970: i32 = 25_567; // Days from 1900-01-01 to 1970-01-01
-        let adjusted = v + DAYS_1900_TO_1970;
-        Ok::<_, Error>(adjusted) // Days since 1900-01-01
-    })
+    (Date32Array, |v: i32| { Ok::<_, Error>(v) })
 ]);
 write_primitive_values!(write_datetime_values, scalar u32::default(), write_u32_le, [
     (TimestampSecondArray, |v: i64| {
@@ -771,12 +768,9 @@ put_primitive_values!(put_date_values, scalar u16::default(), put_u16_le, [
         Ok::<_, Error>(v as u16) // Days since epoch
     })
 ]);
+// CH Date32 wire format is days-since-1970 (signed i32), same epoch as Arrow Date32.
 put_primitive_values!(put_date32_values, scalar i32::default(), put_i32_le, [
-    (Date32Array, |v: i32| {
-        const DAYS_1900_TO_1970: i32 = 25_567; // Days from 1900-01-01 to 1970-01-01
-        let adjusted = v + DAYS_1900_TO_1970;
-        Ok::<_, Error>(adjusted) // Days since 1900-01-01
-    })
+    (Date32Array, |v: i32| { Ok::<_, Error>(v) })
 ]);
 put_primitive_values!(put_datetime_values, scalar u32::default(), put_u32_le, [
     (TimestampSecondArray, |v: i64| {

--- a/clickhouse-arrow/src/arrow/utils.rs
+++ b/clickhouse-arrow/src/arrow/utils.rs
@@ -5,7 +5,26 @@ use arrow::compute::cast;
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
 
-use crate::{Date, DateTime, DynDateTime64, Error, Result, Type, Value};
+use crate::{Date, Date32, DateTime, DynDateTime64, Error, Ipv4, Ipv6, Result, Type, Value};
+
+/// Internal target-width tag for Decimal128 emission.
+///
+/// `array_to_values` collapses an incoming Arrow Decimal128 column into
+/// the narrowest `Value::Decimal{32,64,128}` variant the data fits,
+/// either from the `Type` hint when present, or by inspecting the Arrow
+/// type's precision.
+#[derive(Copy, Clone)]
+enum DecimalNarrow {
+    D32,
+    D64,
+    D128,
+}
+
+/// Convert an Arrow Decimal scale (`i8`) to the canonical `usize` scale
+/// used in `Value::Decimal*` variants. Negative scales are clamped to 0
+/// — they're unrepresentable in our `Value` shape and CH rejects them
+/// at table-creation time, so the clamp is conservative defence.
+fn arrow_scale_to_usize(scale: i8) -> usize { usize::try_from(scale).unwrap_or(0) }
 
 /// Splits a `RecordBatch` into multiple `RecordBatch`es, each containing at most `max` rows.
 ///
@@ -144,15 +163,14 @@ pub fn array_to_values(
         DataType::Float32 => map_or_null(array_to_f32_iter(column)?, Value::Float32),
         DataType::Float64 => map_or_null(array_to_f64_iter(column)?, Value::Float64),
 
-        // Binary-like types (converted to String)
+        // Binary-like types (converted to String).
         DataType::Binary | DataType::LargeBinary | DataType::BinaryView => {
             map_or_null(array_to_binary_iter(column)?, Value::String)
         }
-        DataType::FixedSizeBinary(_) if !matches!(type_hint, Some(Type::Uuid)) => {
-            map_or_null(array_to_binary_iter(column)?, Value::String)
-        }
 
-        // UUID type
+        // UUID — the wire-to-Arrow deserializer normalises CH's two-LE-u64
+        // wire form to canonical RFC 4122 byte order; here the Arrow bytes
+        // are already in the form Uuid::from_bytes expects.
         DataType::FixedSizeBinary(16) if matches!(type_hint, Some(Type::Uuid)) => {
             let iter = array_to_binary_iter(column)?.map(|opt| {
                 opt.and_then(|bytes| {
@@ -165,6 +183,96 @@ pub fn array_to_values(
             });
             map_or_null(iter, Value::Uuid)
         }
+
+        // IPv4 — the deserializer already converts the CH u32-LE wire form
+        // into octet order (a.b.c.d), so the FixedSizeBinary(4) bytes here
+        // are exactly what Ipv4Addr::from([u8;4]) expects.
+        DataType::FixedSizeBinary(4) if matches!(type_hint, Some(Type::Ipv4)) => {
+            let iter = array_to_binary_iter(column)?.map(|opt| {
+                opt.and_then(|bytes| {
+                    (bytes.len() == 4).then(|| {
+                        let mut buf = [0u8; 4];
+                        buf.copy_from_slice(&bytes);
+                        Ipv4(std::net::Ipv4Addr::from(buf))
+                    })
+                })
+            });
+            map_or_null(iter, Value::Ipv4)
+        }
+
+        // IPv6 — wire is the 16 address bytes in network byte order, which
+        // is what Ipv6Addr::from([u8;16]) takes directly.
+        DataType::FixedSizeBinary(16) if matches!(type_hint, Some(Type::Ipv6)) => {
+            let iter = array_to_binary_iter(column)?.map(|opt| {
+                opt.and_then(|bytes| {
+                    (bytes.len() == 16).then(|| {
+                        let mut buf = [0u8; 16];
+                        buf.copy_from_slice(&bytes);
+                        Ipv6(std::net::Ipv6Addr::from(buf))
+                    })
+                })
+            });
+            map_or_null(iter, Value::Ipv6)
+        }
+
+        // Int128 / UInt128 — CH writes the 16 bytes in little-endian.
+        DataType::FixedSizeBinary(16) if matches!(type_hint, Some(Type::Int128)) => {
+            let iter = array_to_binary_iter(column)?.map(|opt| {
+                opt.and_then(|bytes| {
+                    (bytes.len() == 16).then(|| {
+                        let mut buf = [0u8; 16];
+                        buf.copy_from_slice(&bytes);
+                        i128::from_le_bytes(buf)
+                    })
+                })
+            });
+            map_or_null(iter, Value::Int128)
+        }
+        DataType::FixedSizeBinary(16) if matches!(type_hint, Some(Type::UInt128)) => {
+            let iter = array_to_binary_iter(column)?.map(|opt| {
+                opt.and_then(|bytes| {
+                    (bytes.len() == 16).then(|| {
+                        let mut buf = [0u8; 16];
+                        buf.copy_from_slice(&bytes);
+                        u128::from_le_bytes(buf)
+                    })
+                })
+            });
+            map_or_null(iter, Value::UInt128)
+        }
+
+        // Int256 / UInt256 — crate::i256/u256 are byte-array wrappers; the
+        // 32-byte wire payload is stored verbatim. Use full crate paths
+        // here because arrow::datatypes::i256 is a different type that
+        // is also in scope.
+        DataType::FixedSizeBinary(32) if matches!(type_hint, Some(Type::Int256)) => {
+            let iter = array_to_binary_iter(column)?.map(|opt| {
+                opt.and_then(|bytes| {
+                    (bytes.len() == 32).then(|| {
+                        let mut buf = [0u8; 32];
+                        buf.copy_from_slice(&bytes);
+                        crate::i256(buf)
+                    })
+                })
+            });
+            map_or_null(iter, Value::Int256)
+        }
+        DataType::FixedSizeBinary(32) if matches!(type_hint, Some(Type::UInt256)) => {
+            let iter = array_to_binary_iter(column)?.map(|opt| {
+                opt.and_then(|bytes| {
+                    (bytes.len() == 32).then(|| {
+                        let mut buf = [0u8; 32];
+                        buf.copy_from_slice(&bytes);
+                        crate::u256(buf)
+                    })
+                })
+            });
+            map_or_null(iter, Value::UInt256)
+        }
+
+        // Catch-all for FixedSizeBinary with no type_hint match — caller
+        // wants the raw bytes wrapped as a String value.
+        DataType::FixedSizeBinary(_) => map_or_null(array_to_binary_iter(column)?, Value::String),
 
         // String-like types (converted to String)
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
@@ -179,36 +287,79 @@ pub fn array_to_values(
         }
 
         // Decimal types
-        DataType::Decimal128(precision, _) => {
+        //
+        // CH Decimal{32,64,128,256}(scale) all arrive at the Arrow boundary
+        // as Decimal128 or Decimal256, with the CH width encoded in the
+        // Arrow precision (9 → Decimal32, 18 → Decimal64, 38 → Decimal128,
+        // 76 → Decimal256). The scale is the *second* arg of the Arrow type
+        // and lives on the type only — the wire payload is just the raw
+        // signed mantissa.
+        //
+        // Prefer the CH-side scale from type_hint when available (already
+        // the canonical usize); fall back to the Arrow type's scale
+        // otherwise. Emit the narrowest Value variant the data fits.
+        DataType::Decimal128(precision, scale) => {
             let arr = column
                 .as_any()
                 .downcast_ref::<Decimal128Array>()
                 .ok_or_else(|| Error::ArrowDeserialize("Expected Decimal128Array".to_string()))?;
+            let s: usize = match type_hint {
+                Some(Type::Decimal32(s) | Type::Decimal64(s) | Type::Decimal128(s)) => *s,
+                _ => arrow_scale_to_usize(*scale),
+            };
+            let narrow = match type_hint {
+                Some(Type::Decimal32(_)) => DecimalNarrow::D32,
+                Some(Type::Decimal64(_)) => DecimalNarrow::D64,
+                Some(Type::Decimal128(_)) => DecimalNarrow::D128,
+                _ => match *precision {
+                    p if p <= 9 => DecimalNarrow::D32,
+                    p if p <= 18 => DecimalNarrow::D64,
+                    _ => DecimalNarrow::D128,
+                },
+            };
             map_or_null(
-                (0..arr.len()).map(|i| {
-                    if arr.is_null(i) { None } else { Some((*precision as usize, arr.value(i))) }
-                }),
-                |(p, v)| Value::Decimal128(p, v),
+                (0..arr.len()).map(|i| if arr.is_null(i) { None } else { Some(arr.value(i)) }),
+                move |v| match narrow {
+                    DecimalNarrow::D32 =>
+                    {
+                        #[expect(clippy::cast_possible_truncation)]
+                        Value::Decimal32(s, v as i32)
+                    }
+                    DecimalNarrow::D64 =>
+                    {
+                        #[expect(clippy::cast_possible_truncation)]
+                        Value::Decimal64(s, v as i64)
+                    }
+                    DecimalNarrow::D128 => Value::Decimal128(s, v),
+                },
             )
         }
-        DataType::Decimal256(precision, _) => {
+        DataType::Decimal256(_precision, scale) => {
             let arr = column
                 .as_any()
                 .downcast_ref::<Decimal256Array>()
                 .ok_or_else(|| Error::ArrowDeserialize("Expected Decimal256Array".to_string()))?;
+            let s: usize = match type_hint {
+                Some(Type::Decimal256(s)) => *s,
+                _ => arrow_scale_to_usize(*scale),
+            };
             map_or_null(
-                (0..arr.len()).map(|i| {
-                    if arr.is_null(i) {
-                        None
-                    } else {
-                        Some((*precision as usize, arr.value(i).into()))
-                    }
-                }),
-                |(p, v)| Value::Decimal256(p, v),
+                (0..arr.len())
+                    .map(|i| if arr.is_null(i) { None } else { Some((s, arr.value(i).into())) }),
+                |(s, v)| Value::Decimal256(s, v),
             )
         }
 
         // Date types
+        //
+        // Arrow Date32 is i32 days-since-1970, matching CH's Date32. CH's
+        // Date is u16 days-since-1970 (range 1970-01-01..=2149-06-06) and
+        // also round-trips through Arrow Date32. Pick the Value variant
+        // from type_hint so a pre-1970 or post-2149 Date32 value doesn't
+        // panic the u16-bounded Date::from_days path.
+        DataType::Date32 if matches!(type_hint, Some(Type::Date32)) => {
+            map_or_null(array_to_i32_iter(column)?, |d| Value::Date32(Date32(d)))
+        }
         DataType::Date32 => {
             map_or_null(array_to_i32_iter(column)?, |d| Value::Date(Date::from_days(d)))
         }
@@ -1023,24 +1174,63 @@ mod tests {
 
     #[test]
     fn test_decimal128_array() {
+        // Arrow Decimal128(10, 2) is the storage CH uses for Decimal64(2).
+        // Without a type hint we infer the CH width from precision: 10 <= 18
+        // → CH Decimal64. The first tuple member is the CH-side scale.
         let array = Decimal128Array::from_iter_values([12345, -67890])
             .with_precision_and_scale(10, 2)
             .unwrap();
         let result = array_to_values(&array, &DataType::Decimal128(10, 2), None).unwrap();
         assert_eq!(result.len(), 2);
         match &result[0] {
-            Value::Decimal128(p, v) => {
-                assert_eq!(*p, 10);
-                assert_eq!(*v, 12345); // Raw value, represents 123.45 with scale 2
+            Value::Decimal64(s, v) => {
+                assert_eq!(*s, 2);
+                assert_eq!(*v, 12345); // Raw mantissa for 123.45 with scale 2
             }
-            _ => panic!("Expected Decimal128"),
+            other => panic!("Expected Decimal64, got {other:?}"),
         }
         match &result[1] {
-            Value::Decimal128(p, v) => {
-                assert_eq!(*p, 10);
-                assert_eq!(*v, -67890); // Raw value, represents -678.90 with scale 2
+            Value::Decimal64(s, v) => {
+                assert_eq!(*s, 2);
+                assert_eq!(*v, -67890); // Raw mantissa for -678.90 with scale 2
             }
-            _ => panic!("Expected Decimal128"),
+            other => panic!("Expected Decimal64, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decimal128_array_wide() {
+        // Arrow Decimal128(38, 6) maps to CH Decimal128(6).
+        let array = Decimal128Array::from_iter_values([1_234_567_890_i128, -987_654_321_i128])
+            .with_precision_and_scale(38, 6)
+            .unwrap();
+        let result = array_to_values(&array, &DataType::Decimal128(38, 6), None).unwrap();
+        match &result[0] {
+            Value::Decimal128(s, v) => {
+                assert_eq!(*s, 6);
+                assert_eq!(*v, 1_234_567_890_i128);
+            }
+            other => panic!("Expected Decimal128, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_decimal128_array_with_type_hint() {
+        // type_hint Type::Decimal32(2) forces narrow even with a wider
+        // Arrow precision (which a user might pass when reconstructing
+        // from a Decimal32 source).
+        let array = Decimal128Array::from_iter_values([12345, -67890])
+            .with_precision_and_scale(10, 2)
+            .unwrap();
+        let result =
+            array_to_values(&array, &DataType::Decimal128(10, 2), Some(&Type::Decimal32(2)))
+                .unwrap();
+        match &result[0] {
+            Value::Decimal32(s, v) => {
+                assert_eq!(*s, 2);
+                assert_eq!(*v, 12345);
+            }
+            other => panic!("Expected Decimal32, got {other:?}"),
         }
     }
 
@@ -1057,6 +1247,7 @@ mod tests {
 
     #[test]
     fn test_decimal256_array() {
+        // CH Decimal256 always emits Value::Decimal256 with the CH-side scale.
         let array =
             Decimal256Array::from_iter_values([i256::from_i128(12345), i256::from_i128(-67890)])
                 .with_precision_and_scale(20, 2)
@@ -1064,15 +1255,15 @@ mod tests {
         let result = array_to_values(&array, &DataType::Decimal256(20, 2), None).unwrap();
         assert_eq!(result.len(), 2);
         match &result[0] {
-            Value::Decimal256(p, v) => {
-                assert_eq!(*p, 20);
+            Value::Decimal256(s, v) => {
+                assert_eq!(*s, 2);
                 assert_eq!(*v, crate::i256(i256::from_i128(12345).to_be_bytes()));
             }
             _ => panic!("Expected Decimal256"),
         }
         match &result[1] {
-            Value::Decimal256(p, v) => {
-                assert_eq!(*p, 20);
+            Value::Decimal256(s, v) => {
+                assert_eq!(*s, 2);
                 assert_eq!(*v, crate::i256(i256::from_i128(-67890).to_be_bytes()));
             }
             _ => panic!("Expected Decimal256"),

--- a/clickhouse-arrow/src/arrow/utils.rs
+++ b/clickhouse-arrow/src/arrow/utils.rs
@@ -1270,6 +1270,89 @@ mod tests {
         }
     }
 
+    // --- array_to_values type_hint branches: IPv4/6 + wide ints -----------
+    //
+    // These FixedSizeBinary branches only fire when the matching `type_hint`
+    // is supplied; the deserializer has already normalised the bytes to the
+    // form each `Value` variant expects.
+
+    #[test]
+    fn test_array_to_values_ipv4() {
+        let a = std::net::Ipv4Addr::LOCALHOST.octets();
+        let b = std::net::Ipv4Addr::new(192, 168, 1, 42).octets();
+        let array =
+            FixedSizeBinaryArray::try_from_iter([a.as_slice(), b.as_slice()].into_iter()).unwrap();
+        let result =
+            array_to_values(&array, &DataType::FixedSizeBinary(4), Some(&Type::Ipv4)).unwrap();
+        assert_eq!(result, vec![
+            Value::Ipv4(Ipv4(std::net::Ipv4Addr::LOCALHOST)),
+            Value::Ipv4(Ipv4(std::net::Ipv4Addr::new(192, 168, 1, 42))),
+        ]);
+    }
+
+    #[test]
+    fn test_array_to_values_ipv6() {
+        let addr = std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1);
+        let array =
+            FixedSizeBinaryArray::try_from_iter([addr.octets().as_slice()].into_iter()).unwrap();
+        let result =
+            array_to_values(&array, &DataType::FixedSizeBinary(16), Some(&Type::Ipv6)).unwrap();
+        assert_eq!(result, vec![Value::Ipv6(Ipv6(addr))]);
+    }
+
+    #[test]
+    fn test_array_to_values_int128() {
+        let vals = [i128::MIN, 0, i128::MAX];
+        let bytes: Vec<[u8; 16]> = vals.iter().map(|v| v.to_le_bytes()).collect();
+        let array =
+            FixedSizeBinaryArray::try_from_iter(bytes.iter().map(<[u8; 16]>::as_slice)).unwrap();
+        let result =
+            array_to_values(&array, &DataType::FixedSizeBinary(16), Some(&Type::Int128)).unwrap();
+        assert_eq!(result, vec![
+            Value::Int128(i128::MIN),
+            Value::Int128(0),
+            Value::Int128(i128::MAX),
+        ]);
+    }
+
+    #[test]
+    fn test_array_to_values_uint128() {
+        let vals = [0_u128, u128::MAX];
+        let bytes: Vec<[u8; 16]> = vals.iter().map(|v| v.to_le_bytes()).collect();
+        let array =
+            FixedSizeBinaryArray::try_from_iter(bytes.iter().map(<[u8; 16]>::as_slice)).unwrap();
+        let result =
+            array_to_values(&array, &DataType::FixedSizeBinary(16), Some(&Type::UInt128)).unwrap();
+        assert_eq!(result, vec![Value::UInt128(0), Value::UInt128(u128::MAX)]);
+    }
+
+    #[test]
+    fn test_array_to_values_int256() {
+        // The 32 wire bytes are stored verbatim into crate::i256.
+        let raw = [7_u8; 32];
+        let array = FixedSizeBinaryArray::try_from_iter([raw.as_slice()].into_iter()).unwrap();
+        let result =
+            array_to_values(&array, &DataType::FixedSizeBinary(32), Some(&Type::Int256)).unwrap();
+        assert_eq!(result, vec![Value::Int256(crate::i256(raw))]);
+    }
+
+    #[test]
+    fn test_array_to_values_uint256() {
+        let raw = [9_u8; 32];
+        let array = FixedSizeBinaryArray::try_from_iter([raw.as_slice()].into_iter()).unwrap();
+        let result =
+            array_to_values(&array, &DataType::FixedSizeBinary(32), Some(&Type::UInt256)).unwrap();
+        assert_eq!(result, vec![Value::UInt256(crate::u256(raw))]);
+    }
+
+    #[test]
+    fn test_array_to_values_fixed_size_binary_no_hint_is_string() {
+        // No matching type_hint -> the catch-all wraps raw bytes as String.
+        let array = FixedSizeBinaryArray::try_from_iter([b"abcd".as_slice()].into_iter()).unwrap();
+        let result = array_to_values(&array, &DataType::FixedSizeBinary(4), None).unwrap();
+        assert_eq!(result, vec![Value::String(b"abcd".to_vec())]);
+    }
+
     #[test]
     fn test_decimal256_array_error() {
         let array = StringArray::from(vec![""]);

--- a/clickhouse-arrow/src/native.rs
+++ b/clickhouse-arrow/src/native.rs
@@ -4,6 +4,7 @@ pub mod block_info;
 pub(crate) mod client_info;
 pub mod convert;
 pub mod error_codes;
+pub(crate) mod kinds;
 pub mod progress;
 pub(crate) mod protocol;
 pub mod types;

--- a/clickhouse-arrow/src/native/block.rs
+++ b/clickhouse-arrow/src/native/block.rs
@@ -383,3 +383,41 @@ impl ProtocolData<Self, ()> for Block {
         Ok(block)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use tokio::io::AsyncWriteExt;
+
+    use super::*;
+    use crate::io::ClickHouseWrite;
+
+    #[tokio::test]
+    async fn test_value_reader_rejects_non_default_kind() {
+        // The value-mode (native) reader has no Value-domain materialiser for
+        // sparse, so any non-Default kind must be a loud protocol error rather
+        // than a silent mis-frame. Craft a 1-column/1-row block whose column
+        // declares has_custom=1, kind=1 (Sparse).
+        let revision = DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION;
+
+        let mut buffer = Vec::new();
+        BlockInfo::default().write_async(&mut buffer).await.unwrap();
+        buffer.write_var_uint(1).await.unwrap(); // Columns
+        buffer.write_var_uint(1).await.unwrap(); // Rows
+        buffer.write_string("v").await.unwrap();
+        buffer.write_string("Int32").await.unwrap();
+        buffer.write_u8(1).await.unwrap(); // has_custom = 1
+        buffer.write_u8(1).await.unwrap(); // kind = 1 (Sparse)
+
+        let mut state = DeserializerState::default();
+        let mut reader = Cursor::new(buffer);
+        let result =
+            <Block as ProtocolData<Block, ()>>::read_async(&mut reader, revision, (), &mut state)
+                .await;
+        assert!(matches!(
+            result,
+            Err(Error::Protocol(m)) if m.contains("value-mode block reader does not support")
+        ));
+    }
+}

--- a/clickhouse-arrow/src/native/block.rs
+++ b/clickhouse-arrow/src/native/block.rs
@@ -1,9 +1,10 @@
 use std::str::FromStr;
 
 use indexmap::IndexMap;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
 
 use super::block_info::BlockInfo;
+use super::kinds::{SerializationKind, read_serialization_kind};
 use super::protocol::DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION;
 use crate::deserialize::ClickHouseNativeDeserializer;
 use crate::formats::protocol_data::ProtocolData;
@@ -286,10 +287,16 @@ impl ProtocolData<Self, ()> for Block {
                 .await
                 .inspect_err(|e| error!("reading column type (name {name}): {e}"))?;
 
-            // TODO: implement
-            let mut _has_custom_serialization = false;
-            if revision >= DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION {
-                _has_custom_serialization = reader.read_u8().await? != 0;
+            // The value-mode reader only knows how to drive dense column bodies.
+            // Sparse and the other special kinds would need a Value-domain
+            // materialiser; until that exists they're a protocol-level
+            // mismatch, not a silent zero-row result.
+            let kind = read_serialization_kind(reader, revision).await?;
+            if kind != SerializationKind::Default {
+                return Err(Error::Protocol(format!(
+                    "value-mode block reader does not support SerializationInfo kind {kind:?} \
+                     (column {name}); use the Arrow reader for sparse-aware decoding"
+                )));
             }
 
             let type_ = Type::from_str(&type_name).inspect_err(|error| {

--- a/clickhouse-arrow/src/native/kinds.rs
+++ b/clickhouse-arrow/src/native/kinds.rs
@@ -75,6 +75,60 @@ pub(crate) async fn read_serialization_kind<R: ClickHouseRead>(
     })
 }
 
+#[cfg(test)]
+mod tests_async {
+    use std::io::Cursor;
+
+    use super::*;
+
+    const GATE: u64 = DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION;
+
+    async fn read(bytes: &[u8], revision: u64) -> Result<SerializationKind> {
+        let mut reader = Cursor::new(bytes.to_vec());
+        read_serialization_kind(&mut reader, revision).await
+    }
+
+    #[tokio::test]
+    async fn pre_gate_revision_is_default_and_reads_nothing() {
+        // Below the gate, no byte is consumed — pass an empty buffer to prove it.
+        assert_eq!(read(&[], GATE - 1).await.unwrap(), SerializationKind::Default);
+    }
+
+    #[tokio::test]
+    async fn has_custom_zero_is_default() {
+        assert_eq!(read(&[0], GATE).await.unwrap(), SerializationKind::Default);
+    }
+
+    #[tokio::test]
+    async fn each_predefined_kind() {
+        // has_custom=1, then the kind byte.
+        assert_eq!(read(&[1, 0], GATE).await.unwrap(), SerializationKind::Default);
+        assert_eq!(read(&[1, 1], GATE).await.unwrap(), SerializationKind::Sparse);
+        assert_eq!(read(&[1, 2], GATE).await.unwrap(), SerializationKind::Detached);
+        assert_eq!(read(&[1, 3], GATE).await.unwrap(), SerializationKind::DetachedOverSparse);
+        assert_eq!(read(&[1, 4], GATE).await.unwrap(), SerializationKind::Replicated);
+    }
+
+    #[tokio::test]
+    async fn combination_drains_stack_and_leaves_frame_aligned() {
+        // has_custom=1, kind=5 (COMBINATION), varint stack_len=3, then 3 kind
+        // bytes, then a sentinel that must remain unread.
+        let mut reader = Cursor::new(vec![1, 5, 3, 0, 1, 2, 0xAB]);
+        let kind = read_serialization_kind(&mut reader, GATE).await.unwrap();
+        assert_eq!(kind, SerializationKind::Combination);
+        // The next byte must be the sentinel — the 3-entry stack was consumed.
+        assert_eq!(reader.read_u8().await.unwrap(), 0xAB);
+    }
+
+    #[tokio::test]
+    async fn unknown_kind_is_protocol_error() {
+        let err = read(&[1, 6], GATE).await.unwrap_err();
+        assert!(
+            matches!(err, Error::Protocol(msg) if msg.contains("unknown SerializationInfo kind"))
+        );
+    }
+}
+
 /// Sync counterpart of [`read_serialization_kind`] for callers using
 /// the bytes-buffer reader path. Mirrors the async logic exactly. The
 /// sync block reader currently has no callers in the wider tree (every
@@ -112,4 +166,53 @@ pub(crate) fn read_serialization_kind_sync<R: ClickHouseBytesRead>(
             return Err(Error::Protocol(format!("unknown SerializationInfo kind: {other}")));
         }
     })
+}
+
+#[cfg(test)]
+mod tests_sync {
+    use super::*;
+
+    const GATE: u64 = DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION;
+
+    // `ClickHouseBytesRead` is implemented for any `bytes::Buf`; `&[u8]` is one.
+    fn read(mut bytes: &[u8], revision: u64) -> Result<SerializationKind> {
+        read_serialization_kind_sync(&mut bytes, revision)
+    }
+
+    #[test]
+    fn pre_gate_revision_is_default_and_reads_nothing() {
+        assert_eq!(read(&[], GATE - 1).unwrap(), SerializationKind::Default);
+    }
+
+    #[test]
+    fn has_custom_zero_is_default() {
+        assert_eq!(read(&[0], GATE).unwrap(), SerializationKind::Default);
+    }
+
+    #[test]
+    fn each_predefined_kind() {
+        assert_eq!(read(&[1, 0], GATE).unwrap(), SerializationKind::Default);
+        assert_eq!(read(&[1, 1], GATE).unwrap(), SerializationKind::Sparse);
+        assert_eq!(read(&[1, 2], GATE).unwrap(), SerializationKind::Detached);
+        assert_eq!(read(&[1, 3], GATE).unwrap(), SerializationKind::DetachedOverSparse);
+        assert_eq!(read(&[1, 4], GATE).unwrap(), SerializationKind::Replicated);
+    }
+
+    #[test]
+    fn combination_drains_stack_and_leaves_frame_aligned() {
+        // has_custom=1, kind=5, stack_len=3, 3 kind bytes, then a sentinel.
+        let mut buf: &[u8] = &[1, 5, 3, 0, 1, 2, 0xAB];
+        let kind = read_serialization_kind_sync(&mut buf, GATE).unwrap();
+        assert_eq!(kind, SerializationKind::Combination);
+        // The cursor advanced past the 3-entry stack; the sentinel remains.
+        assert_eq!(buf, &[0xAB]);
+    }
+
+    #[test]
+    fn unknown_kind_is_protocol_error() {
+        let err = read(&[1, 6], GATE).unwrap_err();
+        assert!(
+            matches!(err, Error::Protocol(msg) if msg.contains("unknown SerializationInfo kind"))
+        );
+    }
 }

--- a/clickhouse-arrow/src/native/kinds.rs
+++ b/clickhouse-arrow/src/native/kinds.rs
@@ -1,0 +1,115 @@
+//! Per-column `SerializationInfo` kind, read from the native wire.
+//!
+//! See the dialect note at the top of [`crate::native::protocol`] for the
+//! contract: kind 0 is fully supported, kind 1 is reconstructed to a dense
+//! column by the arrow path, every other kind is rejected. This module owns
+//! the wire-format decode for the kind byte (plus the kind 5 stack drain) so
+//! both block readers — arrow and native — share one source of truth.
+
+use tokio::io::AsyncReadExt;
+
+use super::protocol::DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION;
+use crate::io::{ClickHouseBytesRead, ClickHouseRead};
+use crate::{Error, Result};
+
+/// Which `SerializationInfo` kind the server declared for a column.
+///
+/// CH writes one byte after the per-column `has_custom` flag (when the
+/// protocol revision is >= [`DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION`]).
+/// Bytes 0..=4 are predefined stacks; 5 is `COMBINATION` followed by a varint
+/// count + that many u8 kinds (which `read_serialization_kind` drains so the
+/// next column header stays aligned).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SerializationKind {
+    Default,
+    Sparse,
+    Detached,
+    DetachedOverSparse,
+    Replicated,
+    Combination,
+}
+
+const KIND_DEFAULT: u8 = 0;
+const KIND_SPARSE: u8 = 1;
+const KIND_DETACHED: u8 = 2;
+const KIND_DETACHED_OVER_SPARSE: u8 = 3;
+const KIND_REPLICATED: u8 = 4;
+const KIND_COMBINATION: u8 = 5;
+
+/// Read the per-column `SerializationInfo` flag + kind stack.
+///
+/// Returns `Default` for protocols that pre-date the gate or when the
+/// `has_custom` flag is zero. For `COMBINATION` (5), consumes the
+/// varint-length kind list off the wire so the next column header stays
+/// in frame, then returns `Combination` — dispatching is up to the
+/// caller.
+pub(crate) async fn read_serialization_kind<R: ClickHouseRead>(
+    reader: &mut R,
+    revision: u64,
+) -> Result<SerializationKind> {
+    if revision < DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION {
+        return Ok(SerializationKind::Default);
+    }
+    let has_custom = reader.read_u8().await?;
+    if has_custom == 0 {
+        return Ok(SerializationKind::Default);
+    }
+    let kind = reader.read_u8().await?;
+    Ok(match kind {
+        KIND_DEFAULT => SerializationKind::Default,
+        KIND_SPARSE => SerializationKind::Sparse,
+        KIND_DETACHED => SerializationKind::Detached,
+        KIND_DETACHED_OVER_SPARSE => SerializationKind::DetachedOverSparse,
+        KIND_REPLICATED => SerializationKind::Replicated,
+        KIND_COMBINATION => {
+            #[allow(clippy::cast_possible_truncation)]
+            let stack_len = reader.read_var_uint().await? as usize;
+            for _ in 0..stack_len {
+                let _ = reader.read_u8().await?;
+            }
+            SerializationKind::Combination
+        }
+        other => {
+            return Err(Error::Protocol(format!("unknown SerializationInfo kind: {other}")));
+        }
+    })
+}
+
+/// Sync counterpart of [`read_serialization_kind`] for callers using
+/// the bytes-buffer reader path. Mirrors the async logic exactly. The
+/// sync block reader currently has no callers in the wider tree (every
+/// path goes through the async reader), but we keep this symmetric so a
+/// future sync caller stays kind-aware on day one rather than silently
+/// mis-framing the wire.
+#[allow(dead_code)]
+pub(crate) fn read_serialization_kind_sync<R: ClickHouseBytesRead>(
+    reader: &mut R,
+    revision: u64,
+) -> Result<SerializationKind> {
+    if revision < DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION {
+        return Ok(SerializationKind::Default);
+    }
+    let has_custom = reader.try_get_u8()?;
+    if has_custom == 0 {
+        return Ok(SerializationKind::Default);
+    }
+    let kind = reader.try_get_u8()?;
+    Ok(match kind {
+        KIND_DEFAULT => SerializationKind::Default,
+        KIND_SPARSE => SerializationKind::Sparse,
+        KIND_DETACHED => SerializationKind::Detached,
+        KIND_DETACHED_OVER_SPARSE => SerializationKind::DetachedOverSparse,
+        KIND_REPLICATED => SerializationKind::Replicated,
+        KIND_COMBINATION => {
+            #[allow(clippy::cast_possible_truncation)]
+            let stack_len = reader.try_get_var_uint()? as usize;
+            for _ in 0..stack_len {
+                let _ = reader.try_get_u8()?;
+            }
+            SerializationKind::Combination
+        }
+        other => {
+            return Err(Error::Protocol(format!("unknown SerializationInfo kind: {other}")));
+        }
+    })
+}

--- a/clickhouse-arrow/src/native/protocol.rs
+++ b/clickhouse-arrow/src/native/protocol.rs
@@ -1,3 +1,33 @@
+//! `ClickHouse` native TCP protocol — declared dialect.
+//!
+//! `DBMS_TCP_PROTOCOL_VERSION` in this file is what the
+//! client advertises in its Hello packet. The server adopts
+//! `min(client_revision, server_revision)` for the connection, so each
+//! `DBMS_MIN_*_VERSION_WITH_*` constant below is a *gate* — once both
+//! sides are at or past it, that on-wire feature is enabled.
+//!
+//! ### What we support on the column body wire
+//!
+//! `DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION` (54454) turns on
+//! the per-column `has_custom` flag byte plus the kind-stack that
+//! follows. The kinds CH may emit and how this crate handles each:
+//!
+//!   - `Default` (kind 0)              — supported. Native column body.
+//!   - `Sparse` (kind 1)               — supported. Offsets stream then dense nested values;
+//!     reconstructed to a full column on read.
+//!   - `Detached` (kind 2)             — rejected with `Error::Protocol`; internal pipeline
+//!     marshalling, not seen in normal SELECT traffic.
+//!   - `DetachedOverSparse` (kind 3)   — rejected with `Error::Protocol`.
+//!   - `Replicated` (kind 4)           — rejected with `Error::Protocol`; Native-format only, not
+//!     used by `MergeTree`.
+//!   - `Combination` (kind 5)          — rejected with `Error::Protocol`.
+//!
+//! The write path always emits `Default`. CH merges across kinds, so a
+//! table whose existing parts are sparse still accepts our Default
+//! inserts. If a future bump moves the advertised revision past a new
+//! encoding gate, that encoding must be added here before the gate is
+//! enabled — or the rejection path will surface it loudly.
+
 use std::str::FromStr;
 
 use strum::AsRefStr;
@@ -42,6 +72,11 @@ pub(crate) const DBMS_MIN_PROTOCOL_VERSION_WITH_PASSWORD_COMPLEXITY_RULES: u64 =
 pub(crate) const DBMS_MIN_REVISION_WITH_INTERSERVER_SECRET_V2: u64 = 54462;
 pub(crate) const DBMS_MIN_PROTOCOL_VERSION_WITH_TOTAL_BYTES_IN_PROGRESS: u64 = 54463;
 // pub(crate) const DBMS_MIN_PROTOCOL_VERSION_WITH_TIMEZONE_UPDATES: u64 = 54464;
+// Informational: Sparse kind byte first appeared in server revision 54465.
+// Wire-level gating uses the per-column has_custom flag from
+// `DBMS_MIN_PROTOCOL_VERSION_WITH_CUSTOM_SERIALIZATION` (54454), not this
+// revision. Servers older than 54465 will only ever emit kind=0 even when
+// has_custom is set, so we don't need to branch on this in the reader.
 // pub(crate) const DBMS_MIN_REVISION_WITH_SPARSE_SERIALIZATION: u64 = 54465;
 // pub(crate) const DBMS_MIN_REVISION_WITH_SSH_AUTHENTICATION: u64 = 54466;
 /// Send read-only flag for Replicated tables as well

--- a/clickhouse-arrow/src/native/types/deserialize.rs
+++ b/clickhouse-arrow/src/native/types/deserialize.rs
@@ -138,9 +138,6 @@ impl ClickHouseNativeDeserializer for Type {
 // String => Type Deserialization
 // ---
 
-// For Date32: Days from 1900-01-01 to 1970-01-01
-pub(crate) const DAYS_1900_TO_1970: i32 = 25_567;
-
 trait EnumValueType: FromStr + std::fmt::Debug {}
 impl EnumValueType for i8 {}
 impl EnumValueType for i16 {}

--- a/clickhouse-arrow/src/native/values/date.rs
+++ b/clickhouse-arrow/src/native/values/date.rs
@@ -89,14 +89,13 @@ pub struct Date32(pub i32);
 
 #[expect(clippy::cast_possible_truncation)]
 impl Date32 {
-    /// Creates a `Date32` from days since 1900-01-01.
+    /// Creates a `Date32` from days since 1970-01-01.
     pub fn from_days(days: i32) -> Self { Date32(days) }
 
-    /// Creates a `Date32` from milliseconds since 1970-01-01, adjusting to 1900-01-01 epoch.
+    /// Creates a `Date32` from milliseconds since 1970-01-01.
     pub fn from_millis(ms: i64) -> Self {
-        const DAYS_1900_TO_1970: i64 = 25_567; // Days from 1900-01-01 to 1970-01-01
         let days = ms / 86_400_000; // Milliseconds per day
-        Date32((days - DAYS_1900_TO_1970) as i32)
+        Date32(days as i32)
     }
 }
 
@@ -137,10 +136,11 @@ impl FromSql for Date32 {
     }
 }
 
+// CH Date32 wire format is days-since-1970-01-01 (same epoch as Arrow Date32).
 impl From<NaiveDate> for Date32 {
     fn from(other: NaiveDate) -> Self {
         let days =
-            other.signed_duration_since(NaiveDate::from_ymd_opt(1900, 1, 1).unwrap()).num_days();
+            other.signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()).num_days();
         #[expect(clippy::cast_possible_truncation)]
         Date32(days as i32)
     }
@@ -148,7 +148,7 @@ impl From<NaiveDate> for Date32 {
 
 impl From<Date32> for NaiveDate {
     fn from(date: Date32) -> Self {
-        NaiveDate::from_ymd_opt(1900, 1, 1).unwrap() + Duration::days(i64::from(date.0))
+        NaiveDate::from_ymd_opt(1970, 1, 1).unwrap() + Duration::days(i64::from(date.0))
     }
 }
 
@@ -694,7 +694,6 @@ mod chrono_tests {
     use chrono_tz::UTC;
 
     use super::*;
-    use crate::deserialize::DAYS_1900_TO_1970;
 
     #[test]
     fn test_naivedate() {
@@ -748,11 +747,12 @@ mod chrono_tests {
 
     #[test]
     fn test_date32_from_millis() {
-        let days = 0_i32;
-        let ms = i64::from(days + DAYS_1900_TO_1970) * 86_400_000_i64;
-        let date1 = Date32::from_days(days);
-        let date2 = Date32::from_millis(ms);
-        assert_eq!(date1, date2);
+        // Date32 epoch is 1970-01-01 (same as Arrow). 1 day == 86_400_000 ms.
+        let days = 7_i32;
+        let ms = i64::from(days) * 86_400_000_i64;
+        assert_eq!(Date32::from_days(days), Date32::from_millis(ms));
+        // Zero day, zero ms.
+        assert_eq!(Date32::from_days(0), Date32::from_millis(0));
     }
 
     #[cfg(feature = "serde")]

--- a/clickhouse-arrow/tests/e2e_cross_client.rs
+++ b/clickhouse-arrow/tests/e2e_cross_client.rs
@@ -1,0 +1,31 @@
+#![allow(unused_crate_dependencies)]
+
+pub mod common;
+pub mod tests;
+
+const TRACING_DIRECTIVES: &[(&str, &str)] =
+    &[("testcontainers", "debug"), ("clickhouse_arrow", "debug")];
+
+// Cross-client primitive round-trip suite.
+//
+// One direction: raw SQL INSERT (server parses literals) -> arrow read.
+// Other direction: arrow RecordBatch INSERT -> SQL `SELECT toString(col)` read.
+// Both must agree with the ClickHouse server.
+#[cfg(feature = "test-utils")]
+e2e_test!(
+    e2e_cross_client_primitives,
+    tests::cross_client::test_cross_client_primitives,
+    TRACING_DIRECTIVES,
+    None
+);
+
+// Sparse default-fill: a non-nullable Decimal/DateTime64 column dominated by
+// defaults goes sparse on the wire; the omitted rows must reconstruct as the
+// type zero, not NULL.
+#[cfg(feature = "test-utils")]
+e2e_test!(
+    e2e_cross_client_sparse_default_fill,
+    tests::cross_client::test_sparse_default_fill_non_nullable,
+    TRACING_DIRECTIVES,
+    None
+);

--- a/clickhouse-arrow/tests/tests/cross_client.rs
+++ b/clickhouse-arrow/tests/tests/cross_client.rs
@@ -1,0 +1,802 @@
+//! Cross-client primitive round-trip suite.
+//!
+//! The existing e2e tests round-trip `RecordBatch -> insert -> query -> RecordBatch`
+//! entirely through `clickhouse-arrow`. That shape passes even when the crate has
+//! symmetric encoding bugs on both sides: read and write cancel each other.
+//!
+//! This suite breaks the symmetry. For every primitive `ClickHouse` type:
+//!
+//! 1. The table is created with raw DDL using the `ClickHouse` type name.
+//! 2. **Direction A**: rows are inserted via raw SQL literals (so the server parses them). They are
+//!    read back via `client.query_rows()` (so the crate's deserializer runs). The returned `Value`s
+//!    are asserted against expected.
+//! 3. **Direction B**: rows are inserted via an Arrow `RecordBatch` (so the crate's serializer
+//!    runs). They are read back via raw SQL using `toString(col)` (so the server formats the
+//!    value). The text is asserted against `ClickHouse`'s canonical string form.
+//!
+//! If any path drops a sign, swaps endianness, mis-shifts an epoch, mangles
+//! a precision, or otherwise corrupts a value, one of the two directions will
+//! disagree with the server. The fault is localised to read vs. write.
+
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::datatypes::*;
+use arrow::record_batch::RecordBatch;
+use clickhouse_arrow::prelude::*;
+use clickhouse_arrow::test_utils::ClickHouseContainer;
+use clickhouse_arrow::{
+    ArrowFormat, ArrowOptions, Client, ClientBuilder, CompressionMethod, DynDateTime64, Qid,
+    Result, Value,
+};
+use futures_util::StreamExt;
+use tracing::debug;
+
+use crate::common::header;
+
+type ArrowClient = Client<ArrowFormat>;
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+
+async fn connect(ch: &ClickHouseContainer) -> ArrowClient {
+    let native_url = ch.get_native_url();
+    debug!("ClickHouse Native URL: {native_url}");
+
+    ClientBuilder::default()
+        .with_endpoint(native_url)
+        .with_username(&ch.user)
+        .with_password(&ch.password)
+        .with_compression(CompressionMethod::default())
+        .with_ipv4_only(true)
+        .with_arrow_options(
+            ArrowOptions::default()
+                .with_strings_as_strings(true)
+                .with_use_date32_for_date(true)
+                .with_strict_schema(false)
+                .with_nullable_array_default_empty(true)
+                .with_disable_strict_schema_ddl(true),
+        )
+        .build::<ArrowFormat>()
+        .await
+        .expect("failed to build client")
+}
+
+/// CREATE DATABASE + CREATE TABLE using a single `column_type` definition.
+/// Returns `(db, table)` qualified as `db.table` later by the caller.
+async fn create_typed_table(client: &ArrowClient, column_type: &str) -> (String, String) {
+    let qid = Qid::new();
+    let db = format!("xtest_db_{qid}");
+    let table = format!("xtest_t_{qid}");
+
+    client
+        .execute(format!("CREATE DATABASE IF NOT EXISTS {db}"), Some(qid))
+        .await
+        .expect("create db");
+    client
+        .execute(
+            format!(
+                "CREATE TABLE {db}.{table} (id UInt32, v {column_type}) ENGINE = MergeTree ORDER \
+                 BY id"
+            ),
+            Some(qid),
+        )
+        .await
+        .expect("create table");
+
+    (db, table)
+}
+
+async fn drop_typed_table(client: &ArrowClient, db: &str, table: &str) {
+    let _drop_t = client.execute(format!("DROP TABLE IF EXISTS {db}.{table}"), None).await;
+    let _drop_d = client.execute(format!("DROP DATABASE IF EXISTS {db}"), None).await;
+}
+
+// ---------------------------------------------------------------------------
+// Direction A: SQL-literal INSERT -> arrow read
+//
+// `rows` is a list of (id, sql_literal, expected_value). The SQL literal is
+// pasted into `INSERT INTO t VALUES (id, <literal>)` and parsed server-side;
+// the expected_value is what we expect `query_rows` to return for column `v`.
+
+async fn direction_a(client: &ArrowClient, column_type: &str, rows: &[(u32, &str, Value)]) {
+    let (db, table) = create_typed_table(client, column_type).await;
+    let fq = format!("{db}.{table}");
+
+    // INSERT via raw SQL — every value goes through the CH server's parser.
+    let values_list =
+        rows.iter().map(|(id, lit, _)| format!("({id}, {lit})")).collect::<Vec<_>>().join(", ");
+    client
+        .execute(format!("INSERT INTO {fq} VALUES {values_list}"), Some(Qid::new()))
+        .await
+        .expect("raw insert");
+
+    // SELECT via this crate's deserializer.
+    let result: Vec<Vec<Value>> = client
+        .query_rows(format!("SELECT id, v FROM {fq} ORDER BY id"), Some(Qid::new()))
+        .await
+        .expect("query")
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()
+        .expect("collect");
+
+    assert_eq!(result.len(), rows.len(), "[A:{column_type}] row count");
+    let mut mismatches = Vec::new();
+    for (got_row, (id, lit, expected)) in result.iter().zip(rows.iter()) {
+        // Row layout: [id (UInt32), v]
+        assert!(
+            matches!(&got_row[0], Value::UInt32(g) if g == id),
+            "[A:{column_type}] id mismatch on literal {lit}: got {:?}",
+            got_row[0]
+        );
+        if &got_row[1] != expected {
+            mismatches
+                .push(format!("literal {lit:?}: got {:?}, expected {expected:?}", got_row[1]));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "[A:{column_type}] {} mismatch(es):\n  {}",
+        mismatches.len(),
+        mismatches.join("\n  ")
+    );
+
+    drop_typed_table(client, &db, &table).await;
+}
+
+// ---------------------------------------------------------------------------
+// Direction B: arrow RecordBatch INSERT -> SQL toString() read
+//
+// `rows` is a list of (id, ArrayRef-builder-output, expected_text). The Arrow
+// array is pushed through `client.insert`; we then ask the server to format
+// each value with `toString(v)` and compare the returned bytes against the
+// expected canonical text representation.
+
+async fn direction_b(
+    client: &ArrowClient,
+    column_type: &str,
+    arrow_field_type: DataType,
+    ids: Vec<u32>,
+    values: ArrayRef,
+    expected_strings: &[&str],
+) {
+    assert_eq!(ids.len(), expected_strings.len());
+    assert_eq!(values.len(), expected_strings.len());
+
+    let (db, table) = create_typed_table(client, column_type).await;
+    let fq = format!("{db}.{table}");
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("id", DataType::UInt32, false),
+        Field::new("v", arrow_field_type, true),
+    ]));
+    let batch = RecordBatch::try_new(Arc::clone(&schema), vec![
+        Arc::new(UInt32Array::from(ids.clone())) as ArrayRef,
+        values,
+    ])
+    .expect("build record batch");
+
+    // INSERT via this crate's serializer.
+    let _insert = client
+        .insert(format!("INSERT INTO {fq} FORMAT Native"), batch, Some(Qid::new()))
+        .await
+        .expect("arrow insert")
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()
+        .expect("collect insert");
+
+    // SELECT toString(v) — the server formats every value to canonical text.
+    let result: Vec<Vec<Value>> = client
+        .query_rows(format!("SELECT id, toString(v) AS vs FROM {fq} ORDER BY id"), Some(Qid::new()))
+        .await
+        .expect("query")
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()
+        .expect("collect");
+
+    assert_eq!(result.len(), expected_strings.len(), "[B:{column_type}] row count");
+    // Collect mismatches before asserting so a sweep over many values doesn't
+    // stop at the first one — the shape of the disagreement (how many rows,
+    // what the offset pattern looks like) is what locates the bug.
+    let mut mismatches = Vec::new();
+    for (got_row, (id, expected)) in result.iter().zip(ids.iter().zip(expected_strings.iter())) {
+        assert!(
+            matches!(&got_row[0], Value::UInt32(g) if g == id),
+            "[B:{column_type}] id mismatch: got {:?}",
+            got_row[0]
+        );
+        let Value::String(bytes) = &got_row[1] else {
+            panic!(
+                "[B:{column_type}] expected toString to come back as Value::String, got {:?}",
+                got_row[1]
+            );
+        };
+        let got = std::str::from_utf8(bytes).expect("toString utf8");
+        if got != *expected {
+            mismatches.push(format!("id={id}: got {got:?}, expected {expected:?}"));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "[B:{column_type}] {} mismatch(es):\n  {}",
+        mismatches.len(),
+        mismatches.join("\n  ")
+    );
+
+    drop_typed_table(client, &db, &table).await;
+}
+
+// ===========================================================================
+// The actual test — one function with sections per type group.
+// ===========================================================================
+
+/// # Panics
+/// Asserts row-by-row equality on every section — any deserializer drift
+/// from the server's interpretation aborts the test with the offending
+/// literal + decoded value pair. There is no "soft" mode.
+#[expect(clippy::too_many_lines)] // type sweep, scope is the value
+pub async fn test_cross_client_primitives(ch: Arc<ClickHouseContainer>) {
+    let client = connect(ch.as_ref()).await;
+
+    header(Qid::new(), "Section: signed integers");
+    direction_a(&client, "Int8", &[
+        (0, "-128", Value::Int8(i8::MIN)),
+        (1, "0", Value::Int8(0)),
+        (2, "127", Value::Int8(i8::MAX)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Int8",
+        DataType::Int8,
+        vec![0, 1, 2],
+        Arc::new(Int8Array::from(vec![i8::MIN, 0, i8::MAX])) as ArrayRef,
+        &["-128", "0", "127"],
+    )
+    .await;
+
+    direction_a(&client, "Int16", &[
+        (0, "-32768", Value::Int16(i16::MIN)),
+        (1, "0", Value::Int16(0)),
+        (2, "32767", Value::Int16(i16::MAX)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Int16",
+        DataType::Int16,
+        vec![0, 1, 2],
+        Arc::new(Int16Array::from(vec![i16::MIN, 0, i16::MAX])) as ArrayRef,
+        &["-32768", "0", "32767"],
+    )
+    .await;
+
+    direction_a(&client, "Int32", &[
+        (0, "-2147483648", Value::Int32(i32::MIN)),
+        (1, "0", Value::Int32(0)),
+        (2, "2147483647", Value::Int32(i32::MAX)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Int32",
+        DataType::Int32,
+        vec![0, 1, 2],
+        Arc::new(Int32Array::from(vec![i32::MIN, 0, i32::MAX])) as ArrayRef,
+        &["-2147483648", "0", "2147483647"],
+    )
+    .await;
+
+    direction_a(&client, "Int64", &[
+        (0, "-9223372036854775808", Value::Int64(i64::MIN)),
+        (1, "0", Value::Int64(0)),
+        (2, "9223372036854775807", Value::Int64(i64::MAX)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Int64",
+        DataType::Int64,
+        vec![0, 1, 2],
+        Arc::new(Int64Array::from(vec![i64::MIN, 0, i64::MAX])) as ArrayRef,
+        &["-9223372036854775808", "0", "9223372036854775807"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: unsigned integers");
+    direction_a(&client, "UInt8", &[(0, "0", Value::UInt8(0)), (1, "255", Value::UInt8(u8::MAX))])
+        .await;
+    direction_b(
+        &client,
+        "UInt8",
+        DataType::UInt8,
+        vec![0, 1],
+        Arc::new(UInt8Array::from(vec![0_u8, u8::MAX])) as ArrayRef,
+        &["0", "255"],
+    )
+    .await;
+
+    direction_a(&client, "UInt16", &[
+        (0, "0", Value::UInt16(0)),
+        (1, "65535", Value::UInt16(u16::MAX)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "UInt16",
+        DataType::UInt16,
+        vec![0, 1],
+        Arc::new(UInt16Array::from(vec![0_u16, u16::MAX])) as ArrayRef,
+        &["0", "65535"],
+    )
+    .await;
+
+    direction_a(&client, "UInt32", &[
+        (0, "0", Value::UInt32(0)),
+        (1, "4294967295", Value::UInt32(u32::MAX)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "UInt32",
+        DataType::UInt32,
+        vec![0, 1],
+        Arc::new(UInt32Array::from(vec![0_u32, u32::MAX])) as ArrayRef,
+        &["0", "4294967295"],
+    )
+    .await;
+
+    direction_a(&client, "UInt64", &[
+        (0, "0", Value::UInt64(0)),
+        (1, "18446744073709551615", Value::UInt64(u64::MAX)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "UInt64",
+        DataType::UInt64,
+        vec![0, 1],
+        Arc::new(UInt64Array::from(vec![0_u64, u64::MAX])) as ArrayRef,
+        &["0", "18446744073709551615"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: floats");
+    // NaN's bit pattern is preserved (PartialEq on Value::Float uses to_bits).
+    // toString() formats NaN as "nan", inf as "inf", subnormals as decimal text.
+    direction_a(&client, "Float32", &[
+        (0, "0", Value::Float32(0.0)),
+        (1, "-0", Value::Float32(-0.0)),
+        (2, "1.5", Value::Float32(1.5)),
+        (3, "-1.5", Value::Float32(-1.5)),
+        (4, "inf", Value::Float32(f32::INFINITY)),
+        (5, "-inf", Value::Float32(f32::NEG_INFINITY)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Float32",
+        DataType::Float32,
+        vec![0, 1, 2, 3, 4, 5],
+        Arc::new(Float32Array::from(vec![
+            0.0_f32,
+            -0.0_f32,
+            1.5_f32,
+            -1.5_f32,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+        ])) as ArrayRef,
+        &["0", "-0", "1.5", "-1.5", "inf", "-inf"],
+    )
+    .await;
+
+    direction_a(&client, "Float64", &[
+        (0, "0", Value::Float64(0.0)),
+        (1, "-0", Value::Float64(-0.0)),
+        (2, "1.5", Value::Float64(1.5)),
+        (3, "-1.5", Value::Float64(-1.5)),
+        (4, "inf", Value::Float64(f64::INFINITY)),
+        (5, "-inf", Value::Float64(f64::NEG_INFINITY)),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Float64",
+        DataType::Float64,
+        vec![0, 1, 2, 3, 4, 5],
+        Arc::new(Float64Array::from(vec![
+            0.0_f64,
+            -0.0_f64,
+            1.5_f64,
+            -1.5_f64,
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ])) as ArrayRef,
+        &["0", "-0", "1.5", "-1.5", "inf", "-inf"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: Date (UInt16 days-since-1970)");
+    // Date range: 1970-01-01..=2149-06-06 (the post-2106 extension landed in
+    // CH 22.x). 65535 ~= 2149-06-06.
+    direction_a(&client, "Date", &[
+        (0, "'1970-01-01'", Value::Date(Date(0))),
+        (1, "'2024-12-31'", Value::Date(Date(20088))),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Date",
+        DataType::Date32,
+        vec![0, 1],
+        Arc::new(Date32Array::from(vec![0, 20088])) as ArrayRef,
+        &["1970-01-01", "2024-12-31"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: Date32 (Int32 days-since-1970)");
+    // Probes the full Date32 range, including pre-1970 and post-2149 values
+    // that don't fit a plain Date.
+    direction_a(&client, "Date32", &[
+        (0, "'1900-01-01'", Value::Date32(Date32(-25567))),
+        (1, "'1969-12-31'", Value::Date32(Date32(-1))),
+        (2, "'1970-01-01'", Value::Date32(Date32(0))),
+        (3, "'2024-12-31'", Value::Date32(Date32(20088))),
+        (4, "'2106-02-07'", Value::Date32(Date32(49710))),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "Date32",
+        DataType::Date32,
+        vec![0, 1, 2, 3, 4, 5],
+        Arc::new(Date32Array::from(vec![
+            -25567_i32, // 1900-01-01 (Date32-only range)
+            -1,         // 1969-12-31 (Date32-only range)
+            0,          // 1970-01-01
+            20088,      // 2024-12-31
+            49702,      // 2106-01-30 (past plain-Date range)
+            65535,      // 2149-06-06 (u16::MAX boundary)
+        ])) as ArrayRef,
+        &["1900-01-01", "1969-12-31", "1970-01-01", "2024-12-31", "2106-01-30", "2149-06-06"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: DateTime (UInt32 seconds-since-epoch UTC)");
+    direction_a(&client, "DateTime('UTC')", &[
+        (0, "'1970-01-01 00:00:00'", Value::DateTime(DateTime(chrono_tz::UTC, 0))),
+        (1, "'2024-12-31 23:59:59'", Value::DateTime(DateTime(chrono_tz::UTC, 1_735_689_599))),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "DateTime('UTC')",
+        DataType::Timestamp(TimeUnit::Second, Some(Arc::from("UTC"))),
+        vec![0, 1],
+        Arc::new(
+            TimestampSecondArray::from(vec![0_i64, 1_735_689_599]).with_timezone(Arc::from("UTC")),
+        ) as ArrayRef,
+        &["1970-01-01 00:00:00", "2024-12-31 23:59:59"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: DateTime64 — subsecond precision sweep");
+    direction_a(&client, "DateTime64(3, 'UTC')", &[
+        (0, "'1970-01-01 00:00:00.000'", Value::DateTime64(DynDateTime64(chrono_tz::UTC, 0, 3))),
+        (
+            1,
+            "'2024-12-31 23:59:59.999'",
+            Value::DateTime64(DynDateTime64(chrono_tz::UTC, 1_735_689_599_999, 3)),
+        ),
+    ])
+    .await;
+    direction_a(&client, "DateTime64(6, 'UTC')", &[(
+        0,
+        "'2024-06-15 12:00:00.123456'",
+        Value::DateTime64(DynDateTime64(chrono_tz::UTC, 1_718_452_800_123_456, 6)),
+    )])
+    .await;
+    direction_a(&client, "DateTime64(9, 'UTC')", &[(
+        0,
+        "'2024-06-15 12:00:00.123456789'",
+        Value::DateTime64(DynDateTime64(chrono_tz::UTC, 1_718_452_800_123_456_789, 9)),
+    )])
+    .await;
+
+    header(Qid::new(), "Section: String — UTF-8, empty, embedded NUL");
+    direction_a(&client, "String", &[
+        (0, "''", Value::String(b"".to_vec())),
+        (1, "'hello'", Value::String(b"hello".to_vec())),
+        (2, "'café'", Value::String("café".as_bytes().to_vec())),
+        (3, "'a\\0b'", Value::String(b"a\0b".to_vec())),
+    ])
+    .await;
+    direction_b(
+        &client,
+        "String",
+        DataType::Utf8,
+        vec![0, 1, 2, 3],
+        Arc::new(StringArray::from(vec!["", "hello", "café", "a\0b"])) as ArrayRef,
+        &["", "hello", "café", "a\0b"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: UUID");
+    // CH writes UUIDs as a 128-bit value laid out as two LE u64s in
+    // (high, low) order. The `binary_async!(Uuid)` arm reverses each
+    // 8-byte half so bytes land in canonical RFC 4122 order before
+    // Uuid::from_bytes reads them.
+    direction_a(&client, "UUID", &[
+        (0, "'00000000-0000-0000-0000-000000000000'", Value::Uuid(uuid::Uuid::nil())),
+        (
+            1,
+            "'12345678-1234-5678-1234-567812345678'",
+            Value::Uuid(uuid::Uuid::parse_str("12345678-1234-5678-1234-567812345678").unwrap()),
+        ),
+        (
+            2,
+            "'ffffffff-ffff-ffff-ffff-ffffffffffff'",
+            Value::Uuid(uuid::Uuid::parse_str("ffffffff-ffff-ffff-ffff-ffffffffffff").unwrap()),
+        ),
+    ])
+    .await;
+
+    header(Qid::new(), "Section: Bool");
+    direction_a(&client, "Bool", &[(0, "false", Value::UInt8(0)), (1, "true", Value::UInt8(1))])
+        .await;
+    direction_b(
+        &client,
+        "Bool",
+        DataType::Boolean,
+        vec![0, 1],
+        Arc::new(BooleanArray::from(vec![false, true])) as ArrayRef,
+        &["false", "true"],
+    )
+    .await;
+
+    header(Qid::new(), "Section: wide integers (Int128, UInt128)");
+    direction_a(&client, "Int128", &[
+        (0, "-170141183460469231731687303715884105728", Value::Int128(i128::MIN)),
+        (1, "0", Value::Int128(0)),
+        (2, "170141183460469231731687303715884105727", Value::Int128(i128::MAX)),
+    ])
+    .await;
+    direction_a(&client, "UInt128", &[
+        (0, "0", Value::UInt128(0)),
+        (1, "340282366920938463463374607431768211455", Value::UInt128(u128::MAX)),
+    ])
+    .await;
+
+    header(Qid::new(), "Section: Decimal32/64/128 — narrow + wide precision");
+    direction_a(&client, "Decimal32(2)", &[
+        (0, "0", Value::Decimal32(2, 0)),
+        (1, "12345.67", Value::Decimal32(2, 1_234_567)),
+        (2, "-12345.67", Value::Decimal32(2, -1_234_567)),
+    ])
+    .await;
+    direction_a(&client, "Decimal64(4)", &[
+        (0, "0", Value::Decimal64(4, 0)),
+        (1, "12345.6789", Value::Decimal64(4, 123_456_789)),
+        (2, "-12345.6789", Value::Decimal64(4, -123_456_789)),
+    ])
+    .await;
+    direction_a(&client, "Decimal128(6)", &[
+        (0, "0", Value::Decimal128(6, 0)),
+        (1, "123456789012.345678", Value::Decimal128(6, 123_456_789_012_345_678_i128)),
+        (2, "-123456789012.345678", Value::Decimal128(6, -123_456_789_012_345_678_i128)),
+    ])
+    .await;
+
+    header(Qid::new(), "Section: IPv4");
+    direction_a(&client, "IPv4", &[
+        (0, "'127.0.0.1'", Value::Ipv4(Ipv4(std::net::Ipv4Addr::LOCALHOST))),
+        (1, "'192.168.1.42'", Value::Ipv4(Ipv4(std::net::Ipv4Addr::new(192, 168, 1, 42)))),
+    ])
+    .await;
+
+    client.shutdown().await.expect("shutdown");
+}
+
+// ===========================================================================
+// Sparse default-fill correctness.
+//
+// When a non-nullable column is mostly equal to its type default, CH writes
+// the part with Sparse serialization: it ships only the non-default values
+// plus an offset stream, and the reader must reconstruct every omitted row as
+// the type's *zero* value.
+//
+// `arrow::deserialize::sparse::default_array_of` builds that zero for the
+// interleave. It has explicit zero arms for the integer/float/string family
+// but falls through to `new_null_array` for Decimal and the Timestamp
+// (DateTime64) family — so omitted rows in a non-nullable Decimal/DateTime64
+// column come back as NULL instead of 0/epoch. That is silent corruption of a
+// non-nullable column, and it only triggers once the part goes sparse, so the
+// small-row sections above never hit it.
+//
+// These tests force sparse serialization with
+// `ratio_of_defaults_for_sparse_serialization = 0.0` (every column whose ratio
+// of defaults is >= 0 is eligible — i.e. always), read back through Arrow, and
+// assert the default rows are the type zero with `null_count == 0`.
+// ===========================================================================
+
+/// Create a `MergeTree` table that forces sparse serialization for any column
+/// dominated by defaults, returning `(db, table)`.
+async fn create_sparse_forcing_table(client: &ArrowClient, column_type: &str) -> (String, String) {
+    let qid = Qid::new();
+    let db = format!("xsparse_db_{qid}");
+    let table = format!("xsparse_t_{qid}");
+
+    client
+        .execute(format!("CREATE DATABASE IF NOT EXISTS {db}"), Some(qid))
+        .await
+        .expect("create db");
+    client
+        .execute(
+            format!(
+                "CREATE TABLE {db}.{table} (id UInt32, v {column_type}) ENGINE = MergeTree ORDER \
+                 BY id SETTINGS ratio_of_defaults_for_sparse_serialization = 0.0"
+            ),
+            Some(qid),
+        )
+        .await
+        .expect("create table");
+
+    (db, table)
+}
+
+/// Read column `v` back as a single materialized Arrow column.
+///
+/// Concatenates every streamed batch so the assertion sees the whole column
+/// at once (`null_count` is meaningful only over the full column).
+async fn read_v_column(client: &ArrowClient, fq: &str) -> ArrayRef {
+    let batches: Vec<RecordBatch> = client
+        .query(format!("SELECT id, v FROM {fq} ORDER BY id"), Some(Qid::new()))
+        .await
+        .expect("query")
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>>>()
+        .expect("collect batches");
+
+    assert!(!batches.is_empty(), "no batches returned for {fq}");
+    let v_arrays: Vec<&dyn Array> =
+        batches.iter().map(|b| b.column_by_name("v").expect("column v").as_ref()).collect();
+    arrow::compute::concat(&v_arrays).expect("concat v column")
+}
+
+/// Build a mostly-default column body: `total` rows, all the SQL default
+/// literal except a few sentinel rows. Returns the `(id, literal)` insert
+/// pairs plus the set of non-default ids for the caller to assert against.
+fn mostly_default_rows<'a>(
+    total: u32,
+    default_lit: &'a str,
+    sentinels: &'a [(u32, &'a str)],
+) -> Vec<(u32, String)> {
+    (0..total)
+        .map(|id| {
+            let lit =
+                sentinels.iter().find(|(sid, _)| *sid == id).map_or(default_lit, |(_, lit)| lit);
+            (id, lit.to_string())
+        })
+        .collect()
+}
+
+/// Insert `(id, literal)` rows via raw SQL into `fq`.
+async fn sql_insert(client: &ArrowClient, fq: &str, rows: &[(u32, String)]) {
+    let values_list =
+        rows.iter().map(|(id, lit)| format!("({id}, {lit})")).collect::<Vec<_>>().join(", ");
+    client
+        .execute(format!("INSERT INTO {fq} VALUES {values_list}"), Some(Qid::new()))
+        .await
+        .expect("raw insert");
+}
+
+/// # Panics
+/// Asserts the sparse-default rows of non-nullable `Decimal` and `DateTime64`
+/// columns come back as the type zero, not NULL.
+pub async fn test_sparse_default_fill_non_nullable(ch: Arc<ClickHouseContainer>) {
+    const TOTAL: u32 = 256;
+
+    let client = connect(ch.as_ref()).await;
+
+    // --- Decimal64(4): defaults must materialize as 0, not NULL -----------
+    header(Qid::new(), "Sparse: non-nullable Decimal64(4) default-fill");
+    {
+        let (db, table) = create_sparse_forcing_table(&client, "Decimal64(4)").await;
+        let fq = format!("{db}.{table}");
+        // Three non-default sentinels; everything else is 0.
+        let sentinels: &[(u32, &str)] = &[(10, "12.3456"), (100, "-7.8900"), (200, "0.0001")];
+        let rows = mostly_default_rows(TOTAL, "0", sentinels);
+        sql_insert(&client, &fq, &rows).await;
+
+        let col = read_v_column(&client, &fq).await;
+        assert_eq!(col.len(), TOTAL as usize, "[sparse Decimal64] row count");
+        assert_eq!(
+            col.null_count(),
+            0,
+            "[sparse Decimal64] non-nullable column must have no nulls; sparse default rows came \
+             back NULL"
+        );
+        let dec = col.as_any().downcast_ref::<Decimal128Array>().expect("Decimal128Array");
+        // A default (id=0) row: must be raw mantissa 0, not null.
+        assert!(!dec.is_null(0), "[sparse Decimal64] default row 0 is NULL");
+        assert_eq!(dec.value(0), 0_i128, "[sparse Decimal64] default row 0 mantissa");
+        // The sentinel at id=10 = 12.3456 with scale 4 -> mantissa 123456.
+        assert!(!dec.is_null(10), "[sparse Decimal64] sentinel row 10 is NULL");
+        assert_eq!(dec.value(10), 123_456_i128, "[sparse Decimal64] sentinel row 10 mantissa");
+
+        drop_typed_table(&client, &db, &table).await;
+    }
+
+    // --- DateTime64(3, 'UTC'): defaults must materialize as epoch, not NULL
+    header(Qid::new(), "Sparse: non-nullable DateTime64(3) default-fill");
+    {
+        let (db, table) = create_sparse_forcing_table(&client, "DateTime64(3, 'UTC')").await;
+        let fq = format!("{db}.{table}");
+        let sentinels: &[(u32, &str)] =
+            &[(10, "'2024-12-31 23:59:59.999'"), (200, "'2024-06-15 12:00:00.123'")];
+        // The DateTime64 default is the epoch '1970-01-01 00:00:00.000'.
+        let rows = mostly_default_rows(TOTAL, "'1970-01-01 00:00:00.000'", sentinels);
+        sql_insert(&client, &fq, &rows).await;
+
+        let col = read_v_column(&client, &fq).await;
+        assert_eq!(col.len(), TOTAL as usize, "[sparse DateTime64] row count");
+        assert_eq!(
+            col.null_count(),
+            0,
+            "[sparse DateTime64] non-nullable column must have no nulls; sparse default rows came \
+             back NULL"
+        );
+        let ts = col
+            .as_any()
+            .downcast_ref::<TimestampMillisecondArray>()
+            .expect("TimestampMillisecondArray");
+        // Default (id=0) row: epoch == 0 ms, not null.
+        assert!(!ts.is_null(0), "[sparse DateTime64] default row 0 is NULL");
+        assert_eq!(ts.value(0), 0_i64, "[sparse DateTime64] default row 0 epoch ms");
+        // Sentinel id=10 = 2024-12-31 23:59:59.999 UTC -> 1_735_689_599_999 ms.
+        assert!(!ts.is_null(10), "[sparse DateTime64] sentinel row 10 is NULL");
+        assert_eq!(ts.value(10), 1_735_689_599_999_i64, "[sparse DateTime64] sentinel row 10 ms");
+
+        drop_typed_table(&client, &db, &table).await;
+    }
+
+    // --- Nullable(Decimal64(4)): the Nullable default IS null, so the
+    // omitted rows must come back NULL (the `is_nullable` branch of
+    // default_array_of), while the sentinels carry values. -----------------
+    header(Qid::new(), "Sparse: Nullable(Decimal64(4)) default-fill is NULL");
+    {
+        let (db, table) = create_sparse_forcing_table(&client, "Nullable(Decimal64(4))").await;
+        let fq = format!("{db}.{table}");
+        // Mostly NULL; a couple of non-null sentinels. NULL dominates so CH
+        // still serializes the column sparse.
+        let sentinels: &[(u32, &str)] = &[(10, "12.3456"), (200, "-7.8900")];
+        let rows = mostly_default_rows(TOTAL, "NULL", sentinels);
+        sql_insert(&client, &fq, &rows).await;
+
+        let col = read_v_column(&client, &fq).await;
+        assert_eq!(col.len(), TOTAL as usize, "[sparse Nullable Decimal64] row count");
+        // Every default (omitted) row must be NULL; only the two sentinels
+        // are non-null.
+        assert_eq!(
+            col.null_count(),
+            TOTAL as usize - sentinels.len(),
+            "[sparse Nullable Decimal64] omitted rows must materialize as NULL"
+        );
+        let dec = col.as_any().downcast_ref::<Decimal128Array>().expect("Decimal128Array");
+        assert!(dec.is_null(0), "[sparse Nullable Decimal64] default row 0 should be NULL");
+        assert!(!dec.is_null(10), "[sparse Nullable Decimal64] sentinel row 10 is NULL");
+        assert_eq!(dec.value(10), 123_456_i128, "[sparse Nullable Decimal64] sentinel row 10");
+
+        drop_typed_table(&client, &db, &table).await;
+    }
+
+    client.shutdown().await.expect("shutdown");
+}

--- a/clickhouse-arrow/tests/tests/mod.rs
+++ b/clickhouse-arrow/tests/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod arrow;
 pub mod compat;
+pub mod cross_client;
 pub mod native;
 pub mod params;
 


### PR DESCRIPTION
# fix(d-types): cross-client type correctness + SerializationInfo Sparse reads

## The journey

Hey @GeorgeLeePatterson, bit of a long and crazy PR. Very typical @nazq falls down a deep rabbit hole!

This started as a one-line Date32 epoch bug. It ended as a wire-format and protocol-correctness sweep covering five primitive types and the entire `SerializationInfo` stack. LOL, sorry! 

### Where it started — Date32

In prod I was seeing dates rendered ~70 years off (1947 instead of 2017). Tracing through the layers, the deserializer was applying a `-DAYS_1900_TO_1970` (25,567 days) offset to Date32 values on read. The corresponding write path applied `+DAYS_1900_TO_1970`. Read+write cancel; round-trip tests passed; reality was broken. I doubled checked and ClickHouse's actual epoch is `toInt32(toDate32('1970-01-01')) = 0` — same as Arrow. 

### Why round-trip tests didn't catch it

The existing e2e suite goes `Arrow -> insert -> select -> Arrow`. **Symmetric encoding bugs cancel.** Any wire-format error this crate makes on the write side will be silently undone on its own read side, and CI stays green. And up until now that's what I'd been doing, until I side loaded a bunch of data via SQL.

To break the symmetry I added a cross-client suite (`tests/e2e_cross_client.rs`):

- **Direction A**: raw SQL `INSERT INTO t VALUES (...)` — server parses literals — then `SELECT` through `client.query_rows()` — our deserializer runs. Asserts against expected `Value`s.
- **Direction B**: insert via Arrow `RecordBatch` — our serializer runs — then `SELECT toString(v)` — server formats canonically. Asserts against expected text.

Either path disagreeing with the server localises the bug. Symmetric bugs no longer cancel.

### What that surfaced

Once the cross-client harness ran, more types failed:

- **UUID** — CH writes UUIDs as two little-endian u64s in `(high, low)` order, not raw LE bytes. Required per-half byte reverse on both the sync and async `binary!(Uuid)` arms.
- **IPv4/IPv6, Int128/UInt128, Int256/UInt256** — `arrow::utils::array_to_values` had no `type_hint` branches for these; they fell through to the generic `Binary` arm and were emitted as `Value::String`. Each now routes through its proper `Value` variant.
- **Decimal128/256** — the call site ignored `type_hint` for scale and emitted `Decimal128(precision_in_scale_slot, value)`. Reading the canonical scale from the `type_hint` (with an Arrow-side fallback) and narrowing to the smallest fitting variant fixed it.

### The protocol-shape gap

While testing the DateTime64 and UUID direction-A paths against a real MergeTree table, both kept returning zero rows. The INSERT was fine. The SELECT was tearing down the connection mid-stream.

Tracing the wire showed the per-column `SerializationInfo` kind byte that ClickHouse has emitted since protocol revision 54454. Default is kind 0; this is what every existing test happened to hit. But a MergeTree table whose `id`/`timestamp` columns crossed CH's `ratio_of_defaults_for_sparse_serialization` threshold (default 0.9375) was sending kind 1 — **Sparse** — and the deserializer was reading the kind byte as the start of the dense column body. Frame torn. Connection killed. SELECT returned nothing.

We had two viable paths:

1. **Lower the advertised protocol version** below 54454. Would dodge `has_custom` and the kind stack entirely. Also throws away **everything** the higher-revision stack added: chunked transport (54470), parameters (54459), addendum (54458), profile events in INSERT (54456). Backward compatibility purchased at the cost of a wide feature regression.

2. **Implement the encodings the advertised revision promises.** More code, but the protocol contract stays honest.

So I spent the past 24 hours on (2). If we advertise revision 54479, we have to deserialise what 54479 servers send.

### What landed

- New `native/kinds.rs` owns the wire-format decode for the per-column kind byte plus the kind-5 (`COMBINATION`) stack drain. Both block readers — arrow and value-mode — import from it. One source of truth for what each byte means.
- New `arrow/deserialize/sparse.rs` implements the documented `SparseOffsets ++ SparseElements` layout: walks the varint offset stream, deserialises the N dense nested values via the existing typed-builder path, and materialises a full-row Arrow array by interleaving defaults with non-default values (`arrow::compute::interleave`). Works uniformly across every Arrow type.
  - **Offset framing follows the flag, not the row count.** This mirrors CH's `deserializeOffsets`: each varint is a group of defaults, the top bit (`END_OF_GRANULE_FLAG`) marks the terminating entry, and CH *always* writes a final flagged entry. The decoder reads until that terminator is consumed. (An earlier cut stopped once the row count was satisfied and left the terminator on the wire — see "What forced-sparse surfaced" below.)
  - **Default rows are materialised honestly per nullability.** The omitted (default) rows of a sparse column have to be filled in on read. For a **non-nullable** column that's the type's *zero* — numeric `0`, empty string/binary, epoch timestamp, zero-mantissa decimal (precision/scale preserved), zero `Time`/`Duration`. For a **nullable** column the omitted rows are the `Nullable` default, which is NULL. `default_array_of` now takes the field's `is_nullable` and builds the right one-row default array (matching the nested values' `DataType` exactly, including decimal precision/scale and timestamp unit + tz, so `interleave` doesn't trip on metadata). A genuinely unrepresentable non-nullable type is a loud `Error::Protocol`, not a silent NULL fill — same dialect discipline as the kind rejections.
- `arrow/block.rs` dispatches on the kind: `Default` keeps the existing dense path, `Sparse` routes to the new module, and `Detached` / `DetachedOverSparse` / `Replicated` / `Combination` are rejected with `Error::Protocol`. We don't claim to read what we can't actually decode.
- `native/block.rs` (value-mode reader) does not yet have a `Value`-domain materialiser for sparse, so it rejects every non-Default kind explicitly rather than draining bytes and silently mis-framing the dense body. Loud failure beats silent corruption.
- `native/protocol.rs` documents the declared dialect: which kinds we support on read, which we reject, and why (writes are always Default; CH merges across kinds, so existing sparse parts accept our Default inserts).

### What forced-sparse surfaced

The DateTime64/UUID sections only ever hit CH's *natural* sparse threshold with a handful of rows. That was enough to prove the kind byte was read, but too light to exercise the column body — and it masked two further bugs. I added a test that **forces** sparse deterministically (`SETTINGS ratio_of_defaults_for_sparse_serialization = 0.0`) on a column that's ~99% default, then reads it back through Arrow. 

### Test coverage

The new cross-client suite covers every primitive type via both directions. The DateTime64 and UUID sections exercise the sparse path end-to-end against a real MergeTree table; that's why they passed only after Sparse landed.

On top of that:

- **`e2e_cross_client_sparse_default_fill`** forces sparse and asserts the default-fill is correct for three shapes: non-nullable `Decimal64` (defaults → `0`), non-nullable `DateTime64` (defaults → epoch), and `Nullable(Decimal64)` (defaults → NULL). Each asserts the exact `null_count` and the sentinel values, so a regression to either the framing or the default-fill is caught here.
- **`sparse.rs` unit tests** (11, no container) pin the pure decode logic directly: `read_offsets` across all the terminator edge cases (all-default, ends-with-default, ends-with-non-default, fully dense, and the malformed-overshoot error), `default_array_of` for the nullable/non-nullable/unsupported branches, and `materialize` for both zero-fill and null-fill. These are the cheap guards that would have caught the framing desync without needing a server.

## What I didn't do

- **No Value-domain sparse materialiser.** The native block reader rejects sparse rather than implementing it. The value-mode path has no real-world caller hitting sparse today, so the rejection is a contract assertion against future regressions; adding the materialiser is a clean follow-up.
- **No new perf bench.** The sparse hot loop is `pub(crate)` and intentionally so; benching it from `benches/` would require either widening the public API or a slow OPTIMIZE-FINAL-and-poll dance. Existing `query.rs` covers the new `read_serialization_kind` cost on the Default path, which is the common case. I don't think this one is too hard to add but didn't want to block on it.

## Test status

| Gate | Result |
|---|---|
| `cargo +nightly fmt -- --check` | clean |
| `cargo +nightly clippy --all-features --all-targets` | clean |
| `cargo +stable clippy --all-features --all-targets -- -D warnings` | clean |
| Lib unit tests (1051) | pass — includes 11 new `sparse.rs` unit tests |
| `e2e_cross_client` (new) | pass — primitives + forced-sparse default-fill (non-nullable Decimal/DateTime64, Nullable Decimal) |
| `e2e_compat`, `e2e_arrow_chunked`, `e2e_native`, `e2e_params` | pass |
| `e2e_arrow` under default `just test` | pre-existing `WaitContainer(StartupTimeout)` flake — same failure pattern reproduces on `upstream/main`; root cause is the test harness calling `create_container` per-test rather than `get_or_create_container`. Use `just test-serial` (added in this branch) for a clean run on busy machines. |

## One last thing

I added a `just test-serial` recipe — disables both cargo across-binary parallelism (`--jobs 1`) and libtest within-binary parallelism (`--test-threads=1`) so each e2e test can boot its own ClickHouse container without racing the Docker daemon. I kept hitting spurious testing errors, this at least proved the tests pass in isolation.
